### PR TITLE
[DPE-4807] Fix bundle tests

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -112,6 +112,7 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
+      # Commented debugging
       # - name: Setup upterm session
       #   uses: lhotari/action-upterm@v1
       - id: tests-integration

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -45,7 +45,6 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    # runs-on: ubuntu-22.04
     runs-on: [self-hosted, linux, X64, jammy, xlarge]
     timeout-minutes: 120
     strategy:
@@ -83,21 +82,8 @@ jobs:
           juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.28-strict/stable
-          bootstrap-options: " --agent-version 3.4.3"
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
-      - id: cache-image
-        name: Cache Spark Image Locally
-        run: |
-          # Download image for avoiding time out
-          IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0"
-          # IMAGE="ghcr.io/canonical/charmed-spark-kyuubi:3.4-22.04_edge"
-          
-          docker pull $IMAGE 
-          docker save $IMAGE -o image.tar
-          sudo microk8s ctr images import --base-name $IMAGE image.tar
-          docker rmi $IMAGE
-          rm image.tar
       - name: Install tox & poetry
         run: |
           pip install tox

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -82,6 +82,7 @@ jobs:
           juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.28-strict/stable
+          bootstrap-options: " --agent-version 3.4.3"
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - id: cache-image
@@ -111,8 +112,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -112,8 +112,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -116,6 +116,13 @@ jobs:
       # Commented debugging
       # - name: Setup upterm session
       #   uses: lhotari/action-upterm@v1
+      - id: setup-terraform
+        name: Install terraform if needed
+        run: |
+          if ! [ -x "$(command -v terraform)" ]; then
+            echo "Installing terraform from snap"
+            sudo snap install terraform --classic 
+          fi
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -52,14 +52,14 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          # - --backend yaml
+          - --backend yaml
           - --backend terraform
         cos:
-          # -
+          -
           - --cos-model cos
         tox-environments:
-          # - integration-basic
-          # - integration-sparkjob
+          - integration-basic
+          - integration-sparkjob
           - integration-bundle
           - integration-kyuubi
     needs:
@@ -113,9 +113,6 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      # Commented debugging
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
       - id: setup-terraform
         name: Install terraform if needed
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -55,12 +55,12 @@ jobs:
           - --backend terraform
         cos:
           -
-          - --cos-model cos
+          # - --cos-model cos
         tox-environments:
-          - integration-basic
-          - integration-sparkjob
+          # - integration-basic
+          # - integration-sparkjob
           - integration-bundle
-          - integration-kyuubi
+          # - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -111,6 +111,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -51,14 +51,14 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          - --backend yaml
+          # - --backend yaml
           - --backend terraform
         cos:
-          -
+          # -
           - --cos-model cos
         tox-environments:
-          - integration-basic
-          - integration-sparkjob
+          # - integration-basic
+          # - integration-sparkjob
           - integration-bundle
           - integration-kyuubi
     needs:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -112,8 +112,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-22.04
-    timeout-minutes: 240
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -55,12 +55,12 @@ jobs:
           - --backend terraform
         cos:
           -
-          # - --cos-model cos
+          - --cos-model cos
         tox-environments:
-          # - integration-basic
-          # - integration-sparkjob
+          - integration-basic
+          - integration-sparkjob
           - integration-bundle
-          # - integration-kyuubi
+          - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -111,8 +111,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -111,8 +111,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -45,7 +45,8 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    # runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, jammy, xlarge]
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -88,7 +88,8 @@ jobs:
         name: Cache Spark Image Locally
         run: |
           # Download image for avoiding time out
-          IMAGE="ghcr.io/canonical/charmed-spark:3.4-22.04_edge"
+          IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0"
+          # IMAGE="ghcr.io/canonical/charmed-spark-kyuubi:3.4-22.04_edge"
           
           docker pull $IMAGE 
           docker save $IMAGE -o image.tar

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -124,6 +124,6 @@ jobs:
         name: Run Integration Tests
         run: |    
           cd python && tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' ${{ matrix.backend }} ${{ matrix.cos }}
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: canonical/action-tmate@main
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: canonical/action-tmate@main

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -90,7 +90,6 @@ jobs:
         run: |
           # Download image for avoiding time out
           IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0"
-          # IMAGE="ghcr.io/canonical/charmed-spark-kyuubi:3.4-22.04_edge"
           
           docker pull $IMAGE 
           docker save $IMAGE -o image.tar

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -53,15 +53,15 @@ jobs:
       matrix:
         backend:
           - --backend yaml
-          # - --backend terraform
+          - --backend terraform
         cos:
           -
-          # - --cos-model cos
+          - --cos-model cos
         tox-environments:
           - integration-basic
-          # - integration-sparkjob
-          # - integration-bundle
-          # - integration-kyuubi
+          - integration-sparkjob
+          - integration-bundle
+          - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -124,6 +124,3 @@ jobs:
         name: Run Integration Tests
         run: |    
           cd python && tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' ${{ matrix.backend }} ${{ matrix.cos }}
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   uses: canonical/action-tmate@main

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -82,6 +82,7 @@ jobs:
           juju-channel: 3.4/stable
           provider: microk8s
           channel: 1.28-strict/stable
+          bootstrap-options: " --agent-version 3.4.3"
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Install tox & poetry

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -85,6 +85,18 @@ jobs:
           bootstrap-options: " --agent-version 3.4.3"
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
+      - id: cache-image
+        name: Cache Spark Image Locally
+        run: |
+          # Download image for avoiding time out
+          IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0"
+          # IMAGE="ghcr.io/canonical/charmed-spark-kyuubi:3.4-22.04_edge"
+          
+          docker pull $IMAGE 
+          docker save $IMAGE -o image.tar
+          sudo microk8s ctr images import --base-name $IMAGE image.tar
+          docker rmi $IMAGE
+          rm image.tar
       - name: Install tox & poetry
         run: |
           pip install tox

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -51,16 +51,16 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          # - --backend yaml
+          - --backend yaml
           - --backend terraform
         cos:
           -
-          # - --cos-model cos
+          - --cos-model cos
         tox-environments:
-          # - integration-basic
+          - integration-basic
           - integration-sparkjob
           - integration-bundle
-          # - integration-kyuubi
+          - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -111,8 +111,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -51,16 +51,16 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          - --backend yaml
+          # - --backend yaml
           - --backend terraform
         cos:
           -
-          - --cos-model cos
+          # - --cos-model cos
         tox-environments:
-          - integration-basic
+          # - integration-basic
           - integration-sparkjob
           - integration-bundle
-          - integration-kyuubi
+          # - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -111,8 +111,8 @@ jobs:
             echo Skipping unstable tests
             echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - id: tests-integration
         name: Run Integration Tests
         run: |    

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -53,15 +53,15 @@ jobs:
       matrix:
         backend:
           - --backend yaml
-          - --backend terraform
+          # - --backend terraform
         cos:
           -
-          - --cos-model cos
+          # - --cos-model cos
         tox-environments:
           - integration-basic
-          - integration-sparkjob
-          - integration-bundle
-          - integration-kyuubi
+          # - integration-sparkjob
+          # - integration-bundle
+          # - integration-kyuubi
     needs:
       - checks
       - unit-tests
@@ -124,3 +124,6 @@ jobs:
         name: Run Integration Tests
         run: |    
           cd python && tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' ${{ matrix.backend }} ${{ matrix.cos }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: canonical/action-tmate@main

--- a/python/spark_test/resources/bin/pod.sh
+++ b/python/spark_test/resources/bin/pod.sh
@@ -9,7 +9,7 @@ wait_for_pod() {
   POD=$1
   NAMESPACE=$2
 
-  SLEEP_TIME=1
+  SLEEP_TIME=10
   for i in {1..5}
   do
     pod_status=$(kubectl -n ${NAMESPACE} get pod ${POD} | awk '{ print $3 }' | tail -n 1)

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -186,9 +186,7 @@ async def cos(ops_test: OpsTest, cos_model):
 
 
 @pytest.fixture(scope="module")
-async def spark_bundle(
-    ops_test: OpsTest, credentials, bucket, bundle, cos
-):
+async def spark_bundle(ops_test: OpsTest, credentials, bucket, bundle, cos):
     """Deploy all applications in the Kyuubi bundle, wait for all of them to be active,
     and finally yield a list of the names of the applications that were deployed.
     """

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -221,7 +221,7 @@ async def spark_bundle(ops_test: OpsTest, credentials, bucket, bundle, cos):
 
     await ops_test.model.wait_for_idle(
         apps=applications,
-        timeout=2500,
+        timeout=3600,
         idle_period=30,
         status="active",
         raise_on_error=False,

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -187,15 +187,15 @@ async def cos(ops_test: OpsTest, cos_model):
 
 @pytest.fixture(scope="module")
 async def spark_bundle(
-    ops_test: OpsTest, credentials, bucket, service_account, bundle, cos
+    ops_test: OpsTest, credentials, bucket, bundle, cos
 ):
     """Deploy all applications in the Kyuubi bundle, wait for all of them to be active,
     and finally yield a list of the names of the applications that were deployed.
     """
     applications = await (
-        deploy_bundle_yaml(bundle, service_account, bucket, cos, ops_test)
+        deploy_bundle_yaml(bundle, bucket, cos, ops_test)
         if isinstance(bundle, Bundle)
-        else deploy_bundle_terraform(bundle, service_account, bucket, cos, ops_test)
+        else deploy_bundle_terraform(bundle, bucket, cos, ops_test)
     )
 
     if "s3" in applications:

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -172,7 +172,7 @@ def get_secret_data(namespace: str, service_account: str):
 
 async def deploy_bundle_yaml(
     bundle: Bundle,
-    service_account: ServiceAccount,
+    # service_account: ServiceAccount,
     bucket: Bucket,
     cos: str | None,
     ops_test: OpsTest,
@@ -190,8 +190,8 @@ async def deploy_bundle_yaml(
     """
 
     data = {
-        "namespace": service_account.namespace,
-        "service_account": service_account.name,
+        "namespace": ops_test.model_name, # service_account.namespace,
+        "service_account": "kyuubi-test-user",
         "bucket": bucket.bucket_name,
         "s3_endpoint": bucket.s3.meta.endpoint_url,
     } | ({"cos_controller": ops_test.controller_name, "cos_model": cos} if cos else {})
@@ -219,7 +219,7 @@ async def deploy_bundle_yaml(
 
 async def deploy_bundle_terraform(
     bundle: Terraform,
-    service_account: ServiceAccount,
+    # service_account: ServiceAccount,
     bucket: Bucket,
     cos: str | None,
     ops_test: OpsTest,
@@ -229,7 +229,7 @@ async def deploy_bundle_terraform(
             "bucket": bucket.bucket_name,
             "endpoint": bucket.s3.meta.endpoint_url,
         },
-        "kyuubi_user": service_account.name,
+        "kyuubi_user": "kyuubi-test-user",
         "model": ops_test.model_name,
     } | ({"cos_model": cos} if cos else {})
 

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -151,7 +151,7 @@ def get_secret_data(namespace: str, service_account: str):
     secret_name = f"{SECRET_NAME_PREFIX}{service_account}"
     try:
         output = subprocess.run(command, check=True, capture_output=True)
-        # output.stdout.decode(), output.stderr.decode(), output.returncode
+
         result = output.stdout.decode()
         logger.info(f"Command: {command}")
         logger.info(f"Secrets for namespace: {namespace}")
@@ -172,7 +172,6 @@ def get_secret_data(namespace: str, service_account: str):
 
 async def deploy_bundle_yaml(
     bundle: Bundle,
-    # service_account: ServiceAccount,
     bucket: Bucket,
     cos: str | None,
     ops_test: OpsTest,
@@ -219,7 +218,6 @@ async def deploy_bundle_yaml(
 
 async def deploy_bundle_terraform(
     bundle: Terraform,
-    # service_account: ServiceAccount,
     bucket: Bucket,
     cos: str | None,
     ops_test: OpsTest,

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -190,7 +190,7 @@ async def deploy_bundle_yaml(
     """
 
     data = {
-        "namespace": ops_test.model_name, # service_account.namespace,
+        "namespace": ops_test.model_name,  # service_account.namespace,
         "service_account": "kyuubi-test-user",
         "bucket": bucket.bucket_name,
         "s3_endpoint": bucket.s3.meta.endpoint_url,

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -11,7 +11,6 @@ from pytest_operator.plugin import OpsTest
 from spark_test.core.kyuubi import KyuubiClient
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
 from spark_test.fixtures.s3 import bucket, credentials
-from spark_test.fixtures.service_account import registry, service_account
 
 from .helpers import get_kyuubi_credentials, get_postgresql_credentials
 
@@ -46,7 +45,7 @@ async def test_deploy_bundle(ops_test, spark_bundle):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_authentication_is_enforced(ops_test, service_account):
+async def test_authentication_is_enforced(ops_test):
     """Test that the authentication has been enabled in the bundle by default
     and thus Kyuubi accept connections with invalid credentials.
     """
@@ -62,7 +61,7 @@ async def test_authentication_is_enforced(ops_test, service_account):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_jdbc_endpoint(ops_test: OpsTest, service_account):
+async def test_jdbc_endpoint(ops_test: OpsTest):
     """Test that JDBC connection in Kyuubi works out of the box in bundle."""
 
     credentials = await get_kyuubi_credentials(ops_test, "kyuubi")

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -125,7 +125,7 @@ resource "juju_application" "hub" {
   charm {
     name    = "spark-integration-hub-k8s"
     channel = "latest/edge"
-    revision = 8
+    revision = 9
   }
 
   resources = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -55,11 +55,11 @@ resource "juju_application" "kyuubi" {
   charm {
     name    = "kyuubi-k8s"
     channel = "latest/edge"
-    revision = 6
+    revision = 13
   }
 
   resources = {
-      kyuubi-image = 1
+      kyuubi-image = 2
   }
 
   config = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -55,7 +55,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name    = "kyuubi-k8s"
     channel = "latest/edge"
-    revision = 16
+    revision = 17
   }
 
   resources = {
@@ -125,7 +125,7 @@ resource "juju_application" "hub" {
   charm {
     name    = "spark-integration-hub-k8s"
     channel = "latest/edge"
-    revision = 9
+    revision = 10
   }
 
   resources = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -55,7 +55,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name    = "kyuubi-k8s"
     channel = "latest/edge"
-    revision = 14
+    revision = 15
   }
 
   resources = {
@@ -125,7 +125,7 @@ resource "juju_application" "hub" {
   charm {
     name    = "spark-integration-hub-k8s"
     channel = "latest/edge"
-    revision = 6
+    revision = 7
   }
 
   resources = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -55,7 +55,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name    = "kyuubi-k8s"
     channel = "latest/edge"
-    revision = 15
+    revision = 16
   }
 
   resources = {
@@ -125,7 +125,7 @@ resource "juju_application" "hub" {
   charm {
     name    = "spark-integration-hub-k8s"
     channel = "latest/edge"
-    revision = 7
+    revision = 8
   }
 
   resources = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -81,11 +81,11 @@ resource "juju_application" "kyuubi_users" {
   charm {
     name    = "postgresql-k8s"
     channel = "14/stable"
-    revision = 193
+    revision = 281
   }
 
   resources = {
-      postgresql-image = 149
+      postgresql-image = 159
   }
 
   units = 1
@@ -103,11 +103,11 @@ resource "juju_application" "metastore" {
   charm {
     name    = "postgresql-k8s"
     channel = "14/stable"
-    revision = 193
+    revision = 281
   }
 
   resources = {
-      postgresql-image = 149
+      postgresql-image = 159
   }
 
   units = 1

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -125,7 +125,7 @@ resource "juju_application" "hub" {
   charm {
     name    = "spark-integration-hub-k8s"
     channel = "latest/edge"
-    revision = 4
+    revision = 6
   }
 
   resources = {

--- a/releases/3.4/terraform/base/applications.tf
+++ b/releases/3.4/terraform/base/applications.tf
@@ -55,7 +55,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name    = "kyuubi-k8s"
     channel = "latest/edge"
-    revision = 13
+    revision = 14
   }
 
   resources = {

--- a/releases/3.4/terraform/base/integrations.tf
+++ b/releases/3.4/terraform/base/integrations.tf
@@ -71,7 +71,7 @@ resource "juju_integration" "kyuubi_users" {
   }
 }
 
-resource "juju_integration" "kyuubi_users" {
+resource "juju_integration" "kyuubi_service_account" {
   model      = var.model
 
   application {

--- a/releases/3.4/terraform/base/integrations.tf
+++ b/releases/3.4/terraform/base/integrations.tf
@@ -70,3 +70,17 @@ resource "juju_integration" "kyuubi_users" {
     endpoint = "auth-db"
   }
 }
+
+resource "juju_integration" "kyuubi_users" {
+  model      = var.model
+
+  application {
+    name = juju_application.kyuubi.name
+    endpoint = "spark-service-account"
+  }
+
+  application {
+    name = juju_application.hub.name
+    endpoint = "spark-service-account"
+  }
+}

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -58,7 +58,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 4
+    revision: 6
     resources:
       integration-hub-image: 1
     scale: 1
@@ -75,3 +75,5 @@ relations:
   - metastore:database
 - - kyuubi:auth-db
   - kyuubi-users:database
+- - kyuubi:spark-service-account
+  - integration-hub:spark-service-account

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -58,7 +58,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 8
+    revision: 9
     resources:
       integration-hub-image: 1
     scale: 1

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,9 +6,9 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 6
+    revision: 13
     resources:
-      kyuubi-image: 1
+      kyuubi-image: 2
     scale: 1
     options:
       namespace: {{ namespace }}

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 15
+    revision: 16
     resources:
       kyuubi-image: 2
     scale: 1
@@ -58,7 +58,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 7
+    revision: 8
     resources:
       integration-hub-image: 1
     scale: 1

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 14
+    revision: 15
     resources:
       kyuubi-image: 2
     scale: 1
@@ -58,7 +58,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 6
+    revision: 7
     resources:
       integration-hub-image: 1
     scale: 1

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -18,9 +18,9 @@ applications:
   kyuubi-users:
     charm: postgresql-k8s
     channel: 14/stable
-    revision: 193
+    revision: 281
     resources:
-      postgresql-image: 149
+      postgresql-image: 159
     scale: 1
     constraints: arch=amd64
     storage:
@@ -29,9 +29,9 @@ applications:
   metastore:
     charm: postgresql-k8s
     channel: 14/stable
-    revision: 193
+    revision: 281
     resources:
-      postgresql-image: 149
+      postgresql-image: 159
     scale: 1
     constraints: arch=amd64
     storage:

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 13
+    revision: 14
     resources:
       kyuubi-image: 2
     scale: 1

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 16
+    revision: 17
     resources:
       kyuubi-image: 2
     scale: 1
@@ -58,7 +58,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 9
+    revision: 10
     resources:
       integration-hub-image: 1
     scale: 1


### PR DESCRIPTION
The tests updates both the versions of the workloads, but also - most importatnly - move the CI on self-hosted runners. 

In regular github runners, the deployment has now become a bit too large, making things very flaky. Especially when deployed alongside with COS, the tests often hung or failed, becuase of weird errors, that I (or others) could not reproduce locally or on larger machines ([reference](https://chat.canonical.com/canonical/pl/uqokjw66gpyxtem58rfcj657ro)). 

My thought here is that in those conditions, the containers becames either irresponsive or failing, because of concurrency to use the same limited resources. 