### PR TITLE
[DPE-4847] Adding documentation on Azure Storage backends

### DIFF
--- a/releases/3.4/yaml/docs/explanation/e-component-overview.md
+++ b/releases/3.4/yaml/docs/explanation/e-component-overview.md
@@ -8,7 +8,7 @@ The Charmed Spark Solution bundles the following components:
 * [Charmed Bundle](https://charmhub.io/spark-k8s-bundle) to deploy, manage and operate Charmed Spark using [Juju](https://juju.is/). This includes:
   * [Spark History Server](https://charmhub.io/spark-history-server-k8s) to expose a web UI for analysing the logs of previous Spark Jobs
   * [Kyuubi](https://charmhub.io/kyuubi-k8s) to provide a JDBC/ODBC endpoint for running Hive powered by Spark engines
-  * [Spark Integration Hub](https://charmhub.io/spark-integration-hub-k8s) to enable easy configuration of Spark service accounts, providing a native Juju integration with [S3-integrator](https://charmhub.io/s3-integrator) for enabling object-storage persistence and with the [Canonical Observability Stack (COS)](https://charmhub.io/cos-lite) for enabling resource usage monitoring and alerting.   
+  * [Spark Integration Hub](https://charmhub.io/spark-integration-hub-k8s) to enable easy configuration of Spark service accounts, providing a native Juju integration with [S3-integrator](https://charmhub.io/s3-integrator) and [azure-storage-integrator](https://charmhub.io/azure-storage-integrator) for enabling object-storage persistence and with the [Canonical Observability Stack (COS)](https://charmhub.io/cos-lite) for enabling resource usage monitoring and alerting.   
 
 The following image shows how the different artifacts interacts with each other:
 

--- a/releases/3.4/yaml/docs/explanation/e-component-overview.md
+++ b/releases/3.4/yaml/docs/explanation/e-component-overview.md
@@ -8,7 +8,7 @@ The Charmed Spark Solution bundles the following components:
 * [Charmed Bundle](https://charmhub.io/spark-k8s-bundle) to deploy, manage and operate Charmed Spark using [Juju](https://juju.is/). This includes:
   * [Spark History Server](https://charmhub.io/spark-history-server-k8s) to expose a web UI for analysing the logs of previous Spark Jobs
   * [Kyuubi](https://charmhub.io/kyuubi-k8s) to provide a JDBC/ODBC endpoint for running Hive powered by Spark engines
-  * [Spark Integration Hub](https://charmhub.io/spark-integration-hub-k8s) to enable easy configuration of Spark service accounts, providing a native Juju integration with [S3-integrator](https://charmhub.io/s3-integrator) and [azure-storage-integrator](https://charmhub.io/azure-storage-integrator) for enabling object-storage persistence and with the [Canonical Observability Stack (COS)](https://charmhub.io/cos-lite) for enabling resource usage monitoring and alerting.   
+  * [Spark Integration Hub](https://charmhub.io/spark-integration-hub-k8s) to enable easy configuration of Spark service accounts, providing a native Juju integration with [S3 Integrator](https://charmhub.io/s3-integrator) and [Azure Storage Integrator](https://charmhub.io/azure-storage-integrator) for enabling object-storage persistence and with the [Canonical Observability Stack (COS)](https://charmhub.io/cos-lite) for enabling resource usage monitoring and alerting.   
 
 The following image shows how the different artifacts interacts with each other:
 

--- a/releases/3.4/yaml/docs/explanation/e-monitoring.md
+++ b/releases/3.4/yaml/docs/explanation/e-monitoring.md
@@ -89,6 +89,6 @@ Custom alerting rules can also be defined and efficiently managed by [AlertManag
 Logs of driver and executors are stored on the pod local filesystem by default, 
 and they are therefore generally lost once the job finishes and the pod is cleared. 
 
-However, Charmed Spark allows you to store these logs into S3, so that they can 
+However, Charmed Spark allows you to store these logs into S3 or Azure storage, so that they can 
 be re-read and visualized using the Spark History Server, allowing users to monitor 
 and visualize the information and metrics about the job execution.

--- a/releases/3.4/yaml/docs/how-to/h-deploy.md
+++ b/releases/3.4/yaml/docs/how-to/h-deploy.md
@@ -12,7 +12,7 @@ Since Charmed Spark will be managed by Juju, make sure that:
 * you are able to connect to a juju controller
 * you have read-write permissions to either a S3-compatible or an Azure object storage
 
-To set up a Juju controller on K8s and the juju client, you can refer to existing tutorials and documentation, e.g. for [MicroK8s](https://juju.is/docs/olm/get-started-with-juju) and for [AWS EKS](https://juju.is/docs/juju/amazon-eks). Also refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) userguide to install a S3-compatible object storage on MicroK8s (MinIO), EKS (AWS S3) or Azure object storages. 
+To set up a Juju controller on K8s and the Juju client, you can refer to existing tutorials and documentation for [MicroK8s](https://juju.is/docs/olm/get-started-with-juju) and for [AWS EKS](https://juju.is/docs/juju/amazon-eks). Also refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) guide to install an S3-compatible object storage on MicroK8s (MinIO), EKS (AWS S3), or Azure object storages. 
 For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to the documentation or your admin.
 
 Charmed Spark supports native integration with the Canonical Observability Stack (COS). To enable monitoring on top of Charmed Spark, make sure that you have a Juju model with COS correctly deployed. To deploy COS on MicroK8s follow the step-by-step [tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s) or refer to its [documentation](https://charmhub.io/topics/canonical-observability-stack) for more informations.

--- a/releases/3.4/yaml/docs/how-to/h-deploy.md
+++ b/releases/3.4/yaml/docs/how-to/h-deploy.md
@@ -62,11 +62,11 @@ import boto3
 
 config = Config(connect_timeout=60, retries={"max_attempts": 0})
 session = boto3.session.Session(
-    aws_access_key_id=<ACCESS_KEY>, aws_secret_access_key=<SECRET_KEY>
+    aws_access_key_id=<S3_ACCESS_KEY>, aws_secret_access_key=<S3_SECRET_KEY>
 )
 s3 = session.client("s3", endpoint_url=<S3_ENDPOINT>, config=config)
 
-s3.put_object(Bucket=<BUCKET_NAME>, Key=("spark-events/"))
+s3.put_object(Bucket=<S3_BUCKET>, Key=("spark-events/"))
 ```
 
 #### Azure DataLake Storage
@@ -75,7 +75,7 @@ To create a folder on an existing bucket, just place a dummy file in the contain
 For doing this, you can use the `azcli` client snap.
 
 ```shell
-azcli storage blob upload --container-name <container> --name spark-events/a.tmp -f /dev/null
+azcli storage blob upload --container-name <AZURE_CONTAINER> --name spark-events/a.tmp -f /dev/null
 ```
 
 Please refer to [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for more information on how to set up the `azcli` client snap.

--- a/releases/3.4/yaml/docs/how-to/h-deploy.md
+++ b/releases/3.4/yaml/docs/how-to/h-deploy.md
@@ -30,56 +30,6 @@ juju add-model <juju_model>
 
 > Note that this will create a K8s namespace in which the different Charmed Spark components will be deployed to.
 
-#### Configure Object Storage
-
-To store Spark logs on a dedicated directory, you need to create the appropriate folder in the storage backend, that is named `spark-events`. 
-
-This can be done both on S3 and on Azure DataLake Gen2 Storage. 
-
-#### AWS
-
-To create a folder on an existing bucket, just place an empty path object `spark-events`. This can be done in multiple ways depending on the S3 backend interface.
-
-###### Using AWS-CLI Snap
-
-```shell
-TOBE DONE
-```
-
-Please refer to [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for more information on how to set up the AWS CLI client snap.
-
-###### Using Python  
-
-*Install boto*
-
-`pip install boto3`
-
-*Create the S3 bucket*
-
-```python
-from botocore.client import Config
-import boto3
-
-config = Config(connect_timeout=60, retries={"max_attempts": 0})
-session = boto3.session.Session(
-    aws_access_key_id=<S3_ACCESS_KEY>, aws_secret_access_key=<S3_SECRET_KEY>
-)
-s3 = session.client("s3", endpoint_url=<S3_ENDPOINT>, config=config)
-
-s3.put_object(Bucket=<S3_BUCKET>, Key=("spark-events/"))
-```
-
-#### Azure DataLake Storage
-
-To create a folder on an existing bucket, just place a dummy file in the container under the  `spark-events` path.
-For doing this, you can use the `azcli` client snap.
-
-```shell
-azcli storage blob upload --container-name <AZURE_CONTAINER> --name spark-events/a.tmp -f /dev/null
-```
-
-Please refer to [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for more information on how to set up the `azcli` client snap.
-
 ### Deploy Charmed Spark
 
 Charmed Spark can be deployed via 

--- a/releases/3.4/yaml/docs/how-to/h-deploy.md
+++ b/releases/3.4/yaml/docs/how-to/h-deploy.md
@@ -12,8 +12,8 @@ Since Charmed Spark will be managed by Juju, make sure that:
 * you are able to connect to a juju controller
 * you have read-write permissions to either a S3-compatible or an Azure object storage
 
-To set up a Juju controller on K8s and the Juju client, you can refer to existing tutorials and documentation for [MicroK8s](https://juju.is/docs/olm/get-started-with-juju) and for [AWS EKS](https://juju.is/docs/juju/amazon-eks). Also refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) guide to install an S3-compatible object storage on MicroK8s (MinIO), EKS (AWS S3), or Azure object storages. 
-For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to the documentation or your admin.
+To set up a Juju controller on K8s and the Juju client, you can refer to existing tutorials and documentation for [MicroK8s](https://juju.is/docs/olm/get-started-with-juju) and for [AWS EKS](https://juju.is/docs/juju/amazon-eks). Also refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) guide to install and setup kn S3-compatible object storage on MicroK8s (MinIO), EKS (AWS S3), or Azure object storages. 
+For other backends or K8s distributions other than MinIO on MicroK8s and S3 on EKS (e.g. Ceph, Charmed Kubernetes, GKE, etc), please refer to their documentation.
 
 Charmed Spark supports native integration with the Canonical Observability Stack (COS). To enable monitoring on top of Charmed Spark, make sure that you have a Juju model with COS correctly deployed. To deploy COS on MicroK8s follow the step-by-step [tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s) or refer to its [documentation](https://charmhub.io/topics/canonical-observability-stack) for more informations.
 
@@ -51,7 +51,22 @@ pip install jinja2-cli
 
 Once the package is installed, you can render the template using
 
+```shell
 jinja2 -D <key>=<value> bundle.yaml.j2 > bundle.yaml
+```
+
+There exist different YAML bundle, with different configuration options, 
+for S3 and Azure object storage backends. Please, refer to the next sections for 
+more information about how-to configure the deployments for the different 
+object storage backends. [How-to]
+
+Once the bundle is rendered, it can be simply deployed using 
+
+```shell
+juju deploy -m <juju_model> ./bundle.yaml
+```
+
+##### S3 backends
 
 The following table summarizes the properties to be specified for the main bundle
 
@@ -63,18 +78,45 @@ The following table summarizes the properties to be specified for the main bundl
 | bucket          | Name of the S3 bucket to be used for storing logs and data                                                    |
 
 
-Once the bundle is rendered, it can be simply deployed using 
-
-```shell
-juju deploy -m <juju_model> ./bundle.yaml
-```
-
-After some time, you will see that most of the charms will be in a blocked status because of missing or invalid S3 credentials.
+Once the bundle is deployed, you will see that most of the charms will be in a blocked status because of missing or invalid S3 credentials.
 In particular, the `s3` charm should be notifying that it needs to be provided with the access and secret key. This can be done using the action
 
 ```shell
 juju run s3/leader sync-s3-credentials \
   access-key=<access-key> secret-key=<secret-key>
+```
+
+After this, the different charms should start to receive the credentials and move into `active/idle` state.
+
+##### Azure storage backends
+
+The following table summarizes the properties to be specified for the main Azure bundle
+
+| key             | Description                                                                                                   |
+|-----------------|---------------------------------------------------------------------------------------------------------------|
+| service_account | Service Account to be used by Kyuubi Engines                                                                  |
+| namespace       | Namespace where the charms will be deployed. This should correspond to the name of the Juju model to be used. |
+| storage_account | Name of the Azure storage account to be used.                                                                 |
+| container       | Name of the Azure storage container to be used for storing logs and data                                      |
+
+
+Create a Juju secret holding the values for the Azure secret key:
+
+```shell
+juju add-secret azure-credentials secret-key=<AZURE_STORAGE_KEY>
+```
+
+This should prompt the `secret:<secret_id>` that can be used to configure the bundle. 
+To do so, first grant access to the secret for the Azure Storage Integrator charm
+
+```shell
+juju grant-secret <secret_id> azure-storage
+```
+
+Then, you can configure the charm to use the secret 
+
+```shell
+juju config azure-storage credentials=secret:<secret_id> 
 ```
 
 After this, the different charms should start to receive the credentials and move into `active/idle` state.
@@ -104,6 +146,10 @@ Terraform modules make use of the Terraform Juju provider. More information abou
 The [Charmed Spark Terraform module](https://github.com/canonical/spark-k8s-bundle/tree/main/releases/3.4/terraform) is composed of the following submodules:
 * [base module](https://github.com/canonical/spark-k8s-bundle/tree/main/releases/3.4/terraform/base) that bundles all the base resources of the Charmed Spark solution 
 * [cos-integration module](https://github.com/canonical/spark-k8s-bundle/tree/main/releases/3.4/terraform/cos) that bundles all the resources that enable integration with COS
+
+> :warning: Currently, only S3 storage backends are supported for Terraform-based bundles.
+
+
 
 The Charmed Spark Terraform modules can be configured using a `.tfvars.json` file with the following schema:
 

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -170,7 +170,7 @@ how to configure them to make sure that it seamlessly integrates with Charmed Sp
 In fact, to store Spark logs on a dedicated directories, you need to create the appropriate folder (that is named `spark-events`) in the storage backend. 
 This can be done both on S3 and on Azure DataLake Gen2 Storage. Although there are multiple ways to do this, 
 in the following we recommend you to use snap clients. 
-Other possibilities could also be to use [Python libraries](https://github.com/canonical/spark-k8s-bundle/blob/94ac51d519cece9dc6810c7aaa0144a28cd7989b/python/spark_test/core/s3.py).
+Alternatively, use [Python libraries](https://github.com/canonical/spark-k8s-bundle/blob/94ac51d519cece9dc6810c7aaa0144a28cd7989b/python/spark_test/core/s3.py).
 
 #### S3-compatible object storages
 

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -5,7 +5,7 @@ The Charmed Spark solution requires an environment with:
 * A Kubernetes cluster for running the services and workloads
 * An Object storage layer to store persistent data
 
-In the following, we provide details on the technologies currently supported and some further information on how these layers can be setup.
+In the following guide, we provide details on the technologies currently supported and instructions on how these layers can be set up.
 
 ### Kubernetes
 

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -3,22 +3,22 @@
 The Charmed Spark solution requires an environment with:
 
 * A Kubernetes cluster for running the services and workloads
-* A Object storage layer to store persistent data
+* An Object storage layer to store persistent data
 
-In the following, we provide the details of the technologies currently supported and some further information on how these layers can be setup.
+In the following, we provide details on the technologies currently supported and some further information on how these layers can be setup.
 
 ### Kubernetes
 
-The Charmed Spark solution runs on top of several K8s distribution. We recommend you to use 1.29+, but no less than version 1.28. Earlier versions may still be working, although we do not explicitly test them. 
+The Charmed Spark solution runs on top of several K8s distribution. We recommend you to use 1.29+, but no less than version 1.28. 
+Earlier versions may still be working, although we do not explicitly test them. 
 
-There are multiple ways that a K8s cluster can be deployed. 
-We provide full compatibility and support for:
+There are multiple ways that a K8s cluster can be deployed. We provide full compatibility and support for:
 
 * MicroK8s
 * AWS EKS
 * Azure AKS (**Coming Soon**)
 
-The how-to guide belows shows you how to setup up these to be used with Charmed Spark. 
+The how-to guide below shows you how to set up these to be used with Charmed Spark. 
 
 #### MicroK8s
 
@@ -172,14 +172,14 @@ seamless integrates with Charmed Spark.
 In order to connect Charmed Spark with an S3-compatible object storage, 
 the following configurations need to be specified:
 
-* *access_key*
+* *access_key* 
 * *secret_key*
 * *endpoint*
 * *bucket*
 * (optional) *region*
 
 In the following sections, we show how to extract those information in different settings. 
-Leveraging on standard S3 API, you can use the `aws` snap client to perform operations with the
+Leveraging on standard S3 API, you can also use the `aws` snap client to perform operations with the
 S3 service, like creating buckets, upload new content, inspecting the structure and removing data.
 
 To install the AWS CLI client, use 
@@ -191,19 +191,17 @@ sudo snap install aws-cli --classic
 The client can then be configured using the parameters above with 
 
 ```shell
-aws configure set aws_access_key_id <ACCESS_KEY>
-aws configure set aws_secret_access_key <SECRET_KEY>
-aws configure set endpoint_url <AWS_S3_ENDPOINT>
-aws configure set default.region <AWS_REGION>
+aws configure set aws_access_key_id <S3_ACCESS_KEY>
+aws configure set aws_secret_access_key <S3_SECRET_KEY>
+aws configure set endpoint_url <S3_ENDPOINT>
+aws configure set default.region <S3_REGION>
 ```
-
 
 Test that the `aws-cli` client is properly working with 
 
 ```
 aws s3 ls
 ```
-
 
 ##### MicroK8s MinIO
 
@@ -219,29 +217,29 @@ You can then use the following commands to obtain the access key, the access sec
 
 * *access_key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d`
 * *secret_key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d`
-* *MinIO endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
+* *endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
 
 Configure the AWS CLI snap with these parameters. After that, you can create a bucket using
 
 ```shell
-aws s3 mb s3://<BUCKET_NAME>
+aws s3 mb s3://<S3_BUCKET>
 ```
 
 ##### AWS S3
 
-In order to use AWS S3, you need to have a AWS user that has permission to use S3 resource for reading and writing. 
-You can create a new users or use an existing one, as long as you grant permission to S3, either centrally using the IAM console 
+In order to use AWS S3, you need to have an AWS user that has permission to use S3 resource for reading and writing. 
+You can create a new user or use an existing one, as long as you grant permission to S3, either centrally using the IAM console 
 or from the S3 service itself. 
 
 If the service account has `AmazonS3FullAccess` permission, you can create new buckets using
 
 ```bash 
-aws s3api create-bucket --bucket <BUCKET_NAME> --region <AWS_REGION_NAME>
+aws s3api create-bucket --bucket <S3_BUCKET> --region <S3_REGION>
 ```
 
 Note that buckets will be associated to a given AWS region. Once the bucket is created, you can use 
-the access key and the access secret of your service account, also used for authenticating with the AWS CLI profile. 
-The endpoint of the service is `https://s3.<AWS_REGION_NAME>.amazonaws.com`.
+the `access_key` and the `secret_key` of your service account, also used for authenticating with the AWS CLI profile. 
+The endpoint of the service is `https://s3.<S3_REGION>.amazonaws.com`.
 
 #### Azure Storage
 
@@ -257,7 +255,7 @@ In order to connect Charmed Spark with the Azure storage backends (WASB, WASBS, 
 the following configurations need to be specified:
 
 * *storage_account*
-* *secret_key*
+* *storage_key*
 * *container*
 
 You can use the `azcli` snap client to perform operations with the Azure storage services, 
@@ -290,5 +288,5 @@ Once the credentials are set up, you can create a container in your namespace ei
 or also using the `azcli` with
 
 ```shell
-azcli storage container create --fail-on-exist --name <CONTAINER_NAME>
+azcli storage container create --fail-on-exist --name <AZURE_CONTAINER>
 ```

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -1,13 +1,26 @@
 ## How to setup a K8s cluster for Spark
 
-The Charmed Spark solution runs on top of a K8s distribution. We recommend you to use version the latest stable version, but at least version 1.26. There are multiple ways that a K8s cluster can be deployed. Here below we summarize how to setup on K8s on the distributions that we currently support: 
+The Charmed Spark solution requires an environment with:
+
+* A Kubernetes cluster for running the services and workloads
+* A Object storage layer to store persistent data
+
+In the following, we provide the details of the technologies currently supported and some further information on how these layers can be setup.
+
+### Kubernetes
+
+The Charmed Spark solution runs on top of several K8s distribution. We recommend you to use 1.29+, but no less than version 1.28. Earlier versions may still be working, although we do not explicitly test them. 
+
+There are multiple ways that a K8s cluster can be deployed. 
+We provide full compatibility and support for:
 
 * MicroK8s
 * AWS EKS
+* Azure AKS (**Coming Soon**)
 
-The how-to guide belows shows you how to setup all of the services used by Charmed Spark. It may be that given your use-case some of them may not be needed though.
+The how-to guide belows shows you how to setup up these to be used with Charmed Spark. 
 
-### MicroK8s
+#### MicroK8s
 
 [MicroK8s](https://microk8s.io/) is the mightiest tiny Kubernetes distribution around. It can easily installed locally via SNAPs
 
@@ -45,35 +58,18 @@ Enable the K8s features required by the Spark Client Snap
 microk8s.enable dns rbac storage hostpath-storage
 ```
 
-#### S3 Storage
+The MicroK8s cluster is now ready to be used. 
 
-Enable the MinIO storage if you want to store Spark Jobs logs in a S3 compatible object storage to be then exposed via Charmed Spark History Server.
+##### External LoadBalancer
 
-```
-microk8s.enable minio
-```
-
-Refer [here](https://microk8s.io/docs/addon-minio) for more information how to customize your MinIO MicroK8s deployment.
-
-Use the following commands to obtain the access key, the access secret and the MinIO endpoint:
-
-* *access key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d`
-* *secret key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d`
-* *MinIO endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
-
-#### External LoadBalancer
-
-Enable external loadbalancer if you want to expose the Spark History Server UI via a Traefik ingress
+If you want to expose the Spark History Server UI via a Traefik ingress, we need to enable external loadbalancer 
 
 ```
 IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
 microk8s enable metallb:$IPADDR-$IPADDR
 ```
 
-The MicroK8s cluster is now ready to be used. 
-
-
-### AWS EKS
+#### AWS EKS
 
 In order to deploy an EKS cluster, make sure that you have working CLI tools properly installed on your edge machine:
 
@@ -86,7 +82,7 @@ aws sts get-identity-caller
 
 Make also sure that your service account (configured in AWS) has the right permission to create and manage EKS clusters. In general, we recommend the use of profiles when having multiple accounts.
 
-#### Creating the cluster
+##### Creating the cluster
 
 An EKS cluster can be created using `eksctl`, the AWS Management Console, or the AWS CLI. In the following we will use `eksctl`.
 Create a YAML file with the following content 
@@ -151,14 +147,148 @@ users:
 
 The EKS cluster is now ready to be used. 
 
-#### S3 Storage
+#### Object storage
 
-Create a new bucket in the AWS S3 storage if you want to store Spark Jobs logs to be then exposed via Charmed Spark History Server.
+Object storage persistence integration with Charmed Spark is critical for: 
 
-Create a new bucket via AWS CLI 
+* reading and writing application data to be used in Spark Jobs
+* storing Spark Jobs logs to be then exposed via Charmed Spark History Server
+* enable Hive-compatible JDBC/ODBC endpoints provided by Apache Kyuubi to provide datalake capabilities on top of HDFS/Hadoop/object storages
+
+Charmed Spark provides out-of-box integration with the following object storage backends:
+
+* S3-compatible object storages, such as:
+  * MinIO
+  * AWS S3 bucket
+* Azure Storage 
+  * Azure Blob Storage 
+  * Azure DataLake v2 Storage
+
+In the following, we provide guidance on how to setup the different object storages to make sure that it
+seamless integrates with Charmed Spark. 
+
+#### S3-compatible object storages
+
+In order to connect Charmed Spark with an S3-compatible object storage, 
+the following configurations need to be specified:
+
+* *access_key*
+* *secret_key*
+* *endpoint*
+* *bucket*
+* (optional) *region*
+
+In the following sections, we show how to extract those information in different settings. 
+Leveraging on standard S3 API, you can use the `aws` snap client to perform operations with the
+S3 service, like creating buckets, upload new content, inspecting the structure and removing data.
+
+To install the AWS CLI client, use 
+
+```shell
+sudo snap install aws-cli --classic
+```
+
+The client can then be configured using the parameters above with 
+
+```shell
+aws configure set aws_access_key_id <ACCESS_KEY>
+aws configure set aws_secret_access_key <SECRET_KEY>
+aws configure set endpoint_url <AWS_S3_ENDPOINT>
+aws configure set default.region <AWS_REGION>
+```
+
+
+Test that the `aws-cli` client is properly working with 
+
+```
+aws s3 ls
+```
+
+
+##### MicroK8s MinIO
+
+If you have already a MicroK8s cluster running, you can enable the MinIO storage with the dedicated addon
+
+```
+microk8s.enable minio
+```
+
+Refer [here](https://microk8s.io/docs/addon-minio) for more information how to customize your MinIO MicroK8s deployment.
+
+You can then use the following commands to obtain the access key, the access secret and the MinIO endpoint:
+
+* *access_key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_ACCESS_KEY}' | base64 -d`
+* *secret_key*: `microk8s.kubectl get secret -n minio-operator microk8s-user-1 -o jsonpath='{.data.CONSOLE_SECRET_KEY}' | base64 -d`
+* *MinIO endpoint*: `microk8s.kubectl get services -n minio-operator | grep minio | awk '{ print $3 }'`
+
+Configure the AWS CLI snap with these parameters. After that, you can create a bucket using
+
+```shell
+aws s3 mb s3://<BUCKET_NAME>
+```
+
+##### AWS S3
+
+In order to use AWS S3, you need to have a AWS user that has permission to use S3 resource for reading and writing. 
+You can create a new users or use an existing one, as long as you grant permission to S3, either centrally using the IAM console 
+or from the S3 service itself. 
+
+If the service account has `AmazonS3FullAccess` permission, you can create new buckets using
 
 ```bash 
 aws s3api create-bucket --bucket <BUCKET_NAME> --region <AWS_REGION_NAME>
 ```
 
-Use the access key and the access secret of your service account, also used for authenticating with the AWS CLI profile. The endpoint of the bucket is `https://s3.<AWS_REGION_NAME>.amazonaws.com`.
+Note that buckets will be associated to a given AWS region. Once the bucket is created, you can use 
+the access key and the access secret of your service account, also used for authenticating with the AWS CLI profile. 
+The endpoint of the service is `https://s3.<AWS_REGION_NAME>.amazonaws.com`.
+
+#### Azure Storage
+
+Charmed Spark provides out-of-the-box support also for the following Azure storage backends: 
+
+* Azure Blob Storage (both WASB and WASBS)
+* Azure DataLake Gen2 Storage (ABFS and ABFSS)
+
+> :warning: Note that Azure DataLake Gen1 Storage is currently not supported, and it has been deprecated by 
+Azure.
+
+In order to connect Charmed Spark with the Azure storage backends (WASB, WASBS, ABFS and ABFSS) 
+the following configurations need to be specified:
+
+* *storage_account*
+* *secret_key*
+* *container*
+
+You can use the `azcli` snap client to perform operations with the Azure storage services, 
+like creating buckets, upload new content, inspecting the structure and removing data.
+
+To install the `azcli` client, use 
+
+```shell
+sudo snap install azcli
+```
+
+The client can then be configured using the following environment variables
+
+```shell
+export AZURE_STORAGE_ACCOUNT=...
+export AZURE_STORAGE_KEY=...
+```
+
+These credentials can be retrieved from the [Azure portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Storage%2FStorageAccounts), after creating a storage account. 
+When creating the storage account, make sure that you enable "Hierarchical namespace" if you 
+want to use Azure DataLake Gen2 Storage.
+
+Test that the `aws-cli` client is properly working with 
+
+```
+azcli storage container list
+```
+
+Once the credentials are set up, you can create a container in your namespace either from the portal 
+or also using the `azcli` with
+
+```shell
+azcli storage container create --fail-on-exist --name <CONTAINER_NAME>
+```

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -298,7 +298,7 @@ These credentials can be retrieved from the [Azure portal](https://portal.azure.
 When creating the storage account, make sure that you enable "Hierarchical namespace" if you 
 want to use Azure DataLake Gen2 Storage.
 
-Test that the `aws-cli` client is properly working with 
+Test that the `azcli` client is properly working with 
 
 ```
 azcli storage container list

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -147,7 +147,7 @@ users:
 
 The EKS cluster is now ready to be used. 
 
-#### Object storage
+### Object storage
 
 Object storage persistence integration with Charmed Spark is critical for: 
 
@@ -182,6 +182,8 @@ the following configurations need to be specified:
 * *endpoint*
 * *bucket*
 * (optional) *region*
+
+##### Supported S3 backends
 
 In the following sections, we show how to setup and extract those information in 
 MinIO and AWS S3. 

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -174,7 +174,7 @@ Alternatively, use [Python libraries](https://github.com/canonical/spark-k8s-bun
 
 #### S3-compatible object storages
 
-In order to connect Charmed Spark with an S3-compatible object storage, 
+To connect Charmed Spark with an S3-compatible object storage, 
 the following configurations need to be specified:
 
 * *access_key* 

--- a/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
+++ b/releases/3.4/yaml/docs/how-to/h-setup-k8s.md
@@ -267,8 +267,7 @@ Charmed Spark provides out-of-the-box support also for the following Azure stora
 * Azure Blob Storage (both WASB and WASBS)
 * Azure DataLake Gen2 Storage (ABFS and ABFSS)
 
-> :warning: Note that Azure DataLake Gen1 Storage is currently not supported, and it has been deprecated by 
-Azure.
+> :warning: Note that Azure DataLake Gen1 Storage is currently not supported, and it has been deprecated by Azure.
 
 In order to connect Charmed Spark with the Azure storage backends (WASB, WASBS, ABFS and ABFSS) 
 the following configurations need to be specified:

--- a/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
+++ b/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
@@ -22,7 +22,7 @@ Spark Integration Hub can consume:
 
 * `s3-credentials` relation provided by the [S3-integrator](https://charmhub.io/s3-integrator) to enable integration with an S3-compatible 
 object storage system
-* `azure-credentials` relation provided by the [azure-storage-integrator](https://charmhub.io/azure-storage-integrator) to enable integration with Azure Storages, such as Azure Blob Storage (WASB) and Azure DataLake Gen2 Storage (ABFS).
+* `azure-credentials` relation provided by the [Azure Storage Integrator](https://charmhub.io/azure-storage-integrator) to enable integration with Azure Storages, such as Azure Blob Storage (WASB) and Azure DataLake Gen2 Storage (ABFS).
 
 #### S3-compatible object storage
 
@@ -80,10 +80,10 @@ spark.hadoop.fs.s3a.secret.key=<S3_SECRET_KEY>
 
 #### Azure storage
 
-In order to enable integration with an Azure storage, deploy the `azure-storage-integrator` charm
+In order to enable integration with an Azure storage, deploy the Azure Storage Integrator charm
 
 ```shell
-juju deploy azure-storage-integrator --channel stable
+juju deploy azure-storage-integrator --channel edge
 ```
 
 `storage_account` and `container` are provided to the charm using normal configuration, while
@@ -96,7 +96,17 @@ Thus, create a Juju secret holding its value:
 juju add-secret azure-credentials secret-key=<AZURE_STORAGE_KEY>
 ```
 
-This should return a `secret_id` that can be used to configure the charm, i.e.
+This should prompt the `secret:<secret_id>` that can be used to configure 
+the Azure Storage Integrator charm. 
+
+Before configuring the charm, make sure the Azure Storage Integrator charm 
+has granted permission to it:
+
+```shell
+juju grant-secret <secret_id> azure-storage
+```
+
+Then, Use the `secret_id` to configure the charm, i.e.
 
 ```shell
 juju config azure-storage-integrator \
@@ -108,10 +118,10 @@ juju config azure-storage-integrator \
 
 Please refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for guidance on how to set up and retrieve the 
 different parameters for Azure Storage backends. 
-For more information on how to deploy and configure the `azure-storage-integrator` charm refer 
+For more information on how to deploy and configure the Azure Storage Integrator charm refer 
 to the charm documentation.
 
-Once the `azure-storage-integrator` is set up and on an idle/active state, the Spark Integration Hub charm can be integrated with
+Once the Azure Storage Integrator charm is set up and on an `idle/active` state, the Spark Integration Hub charm can be integrated with
 
 ```shell
 juju integrate azure-storage-integrator spark-integration-hub-k8s

--- a/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
+++ b/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
@@ -37,7 +37,7 @@ And configure the appropriate parameters via config options, i.e.
 ```shell
 juju config s3-integration \
   bucket=<S3_BUCKET> \
-  endpoint=<S3_ENDPOINTS> \
+  endpoint=<S3_ENDPOINT> \
   path=spark-events
 ```
 
@@ -45,8 +45,8 @@ In the `s3-integrator`, credentials are fed using an action:
 
 ```shell
 juju run s3-integrator/leader sync-s3-credentials \
-  access-key=$AWS_ACCESS_KEY \
-  secret-key=$AWS_SECRET_KEY
+  access-key=$S3_ACCESS_KEY \
+  secret-key=$S3_SECRET_KEY
 ```
 
 Please refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for guidance on how to set up and retrieve the 
@@ -73,9 +73,9 @@ You should see the following configuration automatically added to your service-a
 spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
 spark.hadoop.fs.s3a.connection.ssl.enabled=false
 spark.hadoop.fs.s3a.path.style.access=true \
-spark.hadoop.fs.s3a.access.key=<ACCESS_KEY>
+spark.hadoop.fs.s3a.access.key=<S3_ACCESS_KEY>
 spark.hadoop.fs.s3a.endpoint=<S3_ENDPOINT>
-spark.hadoop.fs.s3a.secret.key=<SECRET_KEY>
+spark.hadoop.fs.s3a.secret.key=<S3_SECRET_KEY>
 ```
 
 #### Azure storage
@@ -93,7 +93,7 @@ security over its value.
 Thus, create a Juju secret holding its value:
 
 ```shell
-juju add-secret azure-credentials secret-key=<STORAGE_KEY>
+juju add-secret azure-credentials secret-key=<AZURE_STORAGE_KEY>
 ```
 
 This should return a `secret_id` that can be used to configure the charm, i.e.
@@ -101,8 +101,8 @@ This should return a `secret_id` that can be used to configure the charm, i.e.
 ```shell
 juju config azure-storage-integrator \
   credentials=secret:<secret_id> \
-  storage-account=<STORAGE_ACCOUNT> \
-  container=<CONTAINER> \
+  storage-account=<AZURE_STORAGE_ACCOUNT> \
+  container=<AZURE_CONTAINER> \
   path="spark-events"
 ```
 
@@ -128,7 +128,7 @@ spark-client.service-account-registry get-config --username <service_account> --
 You should see the following configuration automatically added to your service-account:
 
 ```shell
-spark.hadoop.fs.azure.account.key.<STORAGE_ACCOUNT>.dfs.core.windows.net=<STORAGE_KEY>
+spark.hadoop.fs.azure.account.key.<AZURE_STORAGE_ACCOUNT>.dfs.core.windows.net=<AZURE_STORAGE_KEY>
 ```
 
 ### Enable Monitoring with Prometheus pushgateway

--- a/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
+++ b/releases/3.4/yaml/docs/how-to/h-use-integration-hub.md
@@ -4,7 +4,7 @@ The Integration Hub charm allows seamless configuration of Charmed Spark service
 via Juju relations, therefore providing a charming, integrated user-experience. 
 
 The Integration Hub charm is part of the Charmed Spark bundle, that can be deployed following 
-[this](/TODO) how-to guide. Alternatively, you can also deploy the 
+[this](/t/charmed-spark-k8s-documentation-how-to-deploy-charmed-spark/10979) how-to guide. Alternatively, you can also deploy the 
 Spark Integration Hub charm standalone by running the following command
 
 ```shell
@@ -13,34 +13,61 @@ juju deploy spark-integration-hub-k8s --channel edge -n1
 
 Once deployed, the Spark Integration Hub will automatically manage the properties for all the service 
 accounts created either with the `spark-client` snap or using the `spark8t` python library. 
-More information on the snap and on the python library can be found 
-[here](/t/spark-client-snap-how-to-manage-spark-accounts/8959) and 
-[here](/t/spark-client-snap-how-to-python-api/8958).
+Refer to the how-to guides for more information on the [snap usage](/t/spark-client-snap-how-to-manage-spark-accounts/8959) and 
+on the [python library](/t/spark-client-snap-how-to-python-api/8958).
 
-### Enable S3 object storage bindings
+### Enable object storage integration
 
-Spark Integration Hub can consume the `s3-credentials` relation provided by the 
-[S3 integrator charm](https://charmhub.io/s3-integrator) to enable integration with an S3-compatible 
-object storage system. 
+Spark Integration Hub can consume:
 
-You can find more information on how to deploy and configure a `s3-integrator` 
-charm [here](https://github.com/canonical/s3-integrator).
+* `s3-credentials` relation provided by the [S3-integrator](https://charmhub.io/s3-integrator) to enable integration with an S3-compatible 
+object storage system
+* `azure-credentials` relation provided by the [azure-storage-integrator](https://charmhub.io/azure-storage-integrator) to enable integration with Azure Storages, such as Azure Blob Storage (WASB) and Azure DataLake Gen2 Storage (ABFS).
 
-Once a `s3-integrator` charm is set up, the Spark Integration Hub charm can be 
-integrated with
+#### S3-compatible object storage
+
+In order to enable integration with a s3-compatible storage, deploy the S3-integrator charm
+
+```shell
+juju deploy s3-integration --channel stable
+```
+
+And configure the appropriate parameters via config options, i.e.
+
+```shell
+juju config s3-integration \
+  bucket=<S3_BUCKET> \
+  endpoint=<S3_ENDPOINTS> \
+  path=spark-events
+```
+
+In the `s3-integrator`, credentials are fed using an action:
+
+```shell
+juju run s3-integrator/leader sync-s3-credentials \
+  access-key=$AWS_ACCESS_KEY \
+  secret-key=$AWS_SECRET_KEY
+```
+
+Please refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for guidance on how to set up and retrieve the 
+different parameters for a MinIO deployed on MicroK8s and AWS S3. 
+For more information on how to deploy and configure the `s3-integrator` charm refer to the charm documentation.
+
+Once the `s3-integrator` is set up and on an idle/active state, the Spark Integration Hub charm can be integrated with
 
 ```shell
 juju integrate s3-integrator spark-integration-hub-k8s
 ```
 
-This will automatically add relevant configuration properties to your spark jobs, 
-that can be verified using the tools provided in the spark-client snap, e.g. 
+This will automatically add relevant configuration properties to your spark jobs,
+depending on the storage backend. 
+This can be verified using the tools provided in the spark-client snap, e.g. 
 
 ```shell
 spark-client.service-account-registry get-config --username <service_account> --namespace <namespace>
 ```
 
-You should see additional configuration automatically added to your service-account, i.e.
+You should see the following configuration automatically added to your service-account:
 
 ```shell
 spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
@@ -51,10 +78,63 @@ spark.hadoop.fs.s3a.endpoint=<S3_ENDPOINT>
 spark.hadoop.fs.s3a.secret.key=<SECRET_KEY>
 ```
 
+#### Azure storage
+
+In order to enable integration with an Azure storage, deploy the `azure-storage-integrator` charm
+
+```shell
+juju deploy azure-storage-integrator --channel stable
+```
+
+`storage_account` and `container` are provided to the charm using normal configuration, while
+`storage_key` is provided using Juju secrets, in order to provide confidentiality and 
+security over its value. 
+
+Thus, create a Juju secret holding its value:
+
+```shell
+juju add-secret azure-credentials secret-key=<STORAGE_KEY>
+```
+
+This should return a `secret_id` that can be used to configure the charm, i.e.
+
+```shell
+juju config azure-storage-integrator \
+  credentials=secret:<secret_id> \
+  storage-account=<STORAGE_ACCOUNT> \
+  container=<CONTAINER> \
+  path="spark-events"
+```
+
+Please refer to the [How-To Setup Environment](/t/charmed-spark-k8s-documentation-how-to-setup-k8s-environment/11618) for guidance on how to set up and retrieve the 
+different parameters for Azure Storage backends. 
+For more information on how to deploy and configure the `azure-storage-integrator` charm refer 
+to the charm documentation.
+
+Once the `azure-storage-integrator` is set up and on an idle/active state, the Spark Integration Hub charm can be integrated with
+
+```shell
+juju integrate azure-storage-integrator spark-integration-hub-k8s
+```
+
+This will automatically add relevant configuration properties to your spark jobs,
+depending on the storage backend. 
+This can be verified using the tools provided in the spark-client snap, e.g. 
+
+```shell
+spark-client.service-account-registry get-config --username <service_account> --namespace <namespace>
+```
+
+You should see the following configuration automatically added to your service-account:
+
+```shell
+spark.hadoop.fs.azure.account.key.<STORAGE_ACCOUNT>.dfs.core.windows.net=<STORAGE_KEY>
+```
+
 ### Enable Monitoring with Prometheus pushgateway
 
 Spark Integration Hub can consume the `pushgateway` relation provided by the 
-[Prometheus Pushgateway charm](https://charmhub.io/prometheus-pushgateway) to enable integration with an S3 object storage. 
+[Prometheus Pushgateway charm](https://charmhub.io/prometheus-pushgateway) to enable integration with an object storage. 
 
 You can find more information on how to deploy and configure a `prometheus-pushgateway` 
 charm [here](https://discourse.charmhub.io/t/prometheus-pushgateway-operator-k8s-docs-using-prometheus-pushgateway/11979/2).


### PR DESCRIPTION
Adding the documentation for the Azure storage support. 

A few restructuring I have been thinking and proposing in the PR:

* Setup the environment. We used to structure the conversation into two setups: one with MicroK8s and one in AWS, covering for each environment both K8s and object storage. However I feel that these are two independent layers, since one could for instance use MicroK8s with an AWS S3 object storage. Also, this was becoming important, since I didn't want to bind Azure storage to Azure Kubernetes Services only. Indeed I have been testing Azure storage mostly on MicroK8s. 

* Streamlining deploy. I have been moving all setup content (for object storage) from how-to-deploy to how-to-setup. Also I have been consistently using snaps and similar user experience to setup the Azure object storage. 

* Small changes to make the presentation independent from S3, but also include Azure storage. 