### PR TITLE
[DPE-6136] Document terminology decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Charmed Spark K8s Bundle
+# Charmed Apache Spark K8s Bundle
 
 [![CharmHub Badge](https://charmhub.io/spark-k8s-bundle/badge.svg)](https://charmhub.io/spark-k8s-bundle)
 [![Tests](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests.yaml/badge.svg?branch=main)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests.yaml?query=branch%3Amain)
 [![Docs](https://github.com/canonical/spark-k8s-bundle/actions/workflows/sync_docs.yaml/badge.svg)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/sync_docs.yaml)
 <!-- [![Release](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-checks.yaml/badge.svg)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-checks.yaml) -->
 
-Charmed Spark bundle as well as [Spark Client Snap](https://snapcraft.io/spark-client) and [spark8t](https://github.com/canonical/spark-k8s-toolkit-py) form the Charmed Spark K8s solution that makes operating Spark workloads on Kubernetes seamless, secure, and production-ready.
+Charmed Apache Spark bundle as well as [Client tools snap for Apache Spark](https://snapcraft.io/spark-client) and [spark8t](https://github.com/canonical/spark-k8s-toolkit-py) form the Charmed Apache Spark solution that makes operating Apache Spark workloads on Kubernetes seamless, secure, and production-ready.
 
-This repository contains relevant artifacts for deploying and testing the Charmed Spark bundle in the following directories:
+This repository contains relevant artifacts for deploying and testing the Charmed Apache Spark bundle in the following directories:
 
-* [python](./python) — contains the `spark-test` package that provides  utilities and fixtures to easily implement Charmed Spark tests. Find more information in its [readme file](./python/README.md)
+* [python](./python) — contains the `spark-test` package that provides  utilities and fixtures to easily implement Charmed Apache Spark tests. Find more information in its [readme file](./python/README.md)
 * [releases](./releases) — contains the artifacts for the different channels, supporting the following backends:
-  * [yaml](./releases/3.4/yaml) — using Juju YAML bundles to easily deploy Charmed Spark on K8s
-  * [terraform](releases/3.4/terraform) — using Terraform scripts to deploy Charmed Spark using the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju)
+  * [yaml](./releases/3.4/yaml) — using Juju YAML bundles to easily deploy Charmed Apache Spark on K8s
+  * [terraform](releases/3.4/terraform) — using Terraform scripts to deploy Charmed Apache Spark using the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju)
 
-The Charmed Spark K8s bundle is also available on [Charmhub](https://charmhub.io/spark-k8s-bundle).
+The Charmed Apache Spark K8s bundle is also available on [Charmhub](https://charmhub.io/spark-k8s-bundle).
 
 ## Requirements
 
@@ -22,7 +22,7 @@ The minimum requirements are as follows:
 
 * 8 GB of HDD.
 * 2 CPU threads per host.
-* Access to the internet for downloading the [Canonical Spark Image](https://github.com/canonical/charmed-spark-rock/pkgs/container/charmed-spark).
+* Access to the internet for downloading the [Canonical Apache Spark Image](https://github.com/canonical/charmed-spark-rock/pkgs/container/charmed-spark).
 * Access to a Kubernetes cluster, e.g. [MicroK8s](https://microk8s.io/) or [Charmed Kubernetes](https://ubuntu.com/kubernetes/charmed-k8s).
 
 A production-ready solution might require more resources.
@@ -31,20 +31,20 @@ A production-ready solution might require more resources.
 
 ## Monitoring
 
-Charmed Spark supports native integration with the Canonical Observability Stack (COS). If you want to enable monitoring on top of Charmed Spark, make sure that you have a Juju model with COS correctly deployed and see the [How to enable monitoring guide](https://charmhub.io/spark-k8s-bundle/docs/h-spark-monitoring). To deploy COS on MicroK8s, follow the [step-by-step tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s). For more information about Charmed Spark and COS integration, refer to the [COS documentation](https://charmhub.io/topics/canonical-observability-stack) and the [monitoring explanation section](/t/charmed-spark-documentation-explanation-monitoring/14299).
+Charmed Apache Spark supports native integration with the Canonical Observability Stack (COS). If you want to enable monitoring on top of Charmed Apache Spark, make sure that you have a Juju model with COS correctly deployed and see the [How to enable monitoring guide](https://charmhub.io/spark-k8s-bundle/docs/h-spark-monitoring). To deploy COS on MicroK8s, follow the [step-by-step tutorial](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s). For more information about Charmed Apache Spark and COS integration, refer to the [COS documentation](https://charmhub.io/topics/canonical-observability-stack) and the [monitoring explanation section](/t/charmed-spark-documentation-explanation-monitoring/14299).
 
 ## Security
 
 For information on security features and the use of cryptography, see the [Security explanation](https://charmhub.io/spark-k8s-bundle/docs/e-security) page.
 
-Security issues in the Charmed Spark K8s bundle can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
+Security issues in the Charmed Apache Spark K8s bundle can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
 
 ## Contributing
 
-Canonical welcomes contributions to the Charmed Spark bundle. Please check out our [contribution guidelines](python/CONTRIBUTING.md) if you're interested in contributing to the solution. If you truly enjoy working on open-source projects like this one and you would like to be part of the OSS revolution, please don't forget to check out the [career opportunities](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/).  
+Canonical welcomes contributions to the Charmed Apache Spark bundle. Please check out our [contribution guidelines](python/CONTRIBUTING.md) if you're interested in contributing to the solution. If you truly enjoy working on open-source projects like this one and you would like to be part of the OSS revolution, please don't forget to check out the [career opportunities](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/).  
 
 ## License
 
-The Charmed Spark bundle is free software, distributed under the Apache Software License, version 2.0.
+The Charmed Apache Spark bundle is free software, distributed under the Apache Software License, version 2.0.
 
 See [LICENSE](LICENSE) for more information.

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This documents explains the processes and practices recommended for contributing
 - All enhancements require review before being merged. Code review typically examines
   - code quality
   - test coverage
-  - user experience for interacting with the other components of the Charmed Spark solution.
+  - user experience for interacting with the other components of the Charmed Apache Spark solution.
 - Please help us out in ensuring easy to review branches by rebasing your pull request branch onto the `main` branch. This also avoids merge commits and creates a linear Git commit history.
 
 To build and develop the package in this repository, we advise to use [Poetry](https://python-poetry.org/). For installing poetry on different platforms, please refer to [here](https://python-poetry.org/docs/#installation).

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -68,6 +68,27 @@ Although Discourse content can be edited directly, unless the modifications are 
 4. Discourse Gatekeeper will raise a new PR or add new commits to an open Discourse PR, tracking the `discourse-gatekeeper/migrate` branch. The [sync_docs.yaml](https://github.com/canonical/spark-k8s-bundle/blob/main/.github/workflows/sync_docs.yaml) GitHub Actions provides further details on the Gatekeeper integration that can be run (a) in a scheduled fashion every night; (b) as a part of pull request CI, and (c) can be triggered manually. If new topics are referenced in the main index file on Discourse, these will be added to `docs/index.md` and the new topics pulled from Discourse.
 5. Once Gatekeeper has raised a new or updated an existing PR, feel free to close the initial PR manually created in step 2, with a comment referring to the PR created by Gatekeeper. If the initial PR was referring to a ticket, add the ticket to either the title or the description of the GateKeeper PR.
 
+### Terminology
+
+Apache®, [Apache Spark, Spark™](https://spark.apache.org/) and their respective logos are either registered trademarks or trademarks of the [Apache Software Foundation](https://www.apache.org/) in the United States and/or other countries.
+
+For documentation in this repository the following conventions are applied (see the table below).
+
+| Full form | Alternatives | Incorrect examples |
+| -------- | ------- | ------- |
+| Apache Spark | Alternatives | Incorrect examples |
+| Charmed Apache Spark | | |
+| Spark History Server | Apache Spark History Server | |
+| Spark jobs | | Spark Jobs |
+| Spark Driver | | |
+| Spark Executor | | |
+| Spark Context | | |
+| Integration Hub for Apache Spark | Integration Hub | Spark Integration Hub |
+| Client tools snap for Apache Spark | | Spark client snap, tools snap |
+
+The full form must be used at least once per page.
+The full form must be used at the first entry to the page’s headings, body of text, callouts, and graphics.
+For subsequent usage, the full form can be substituted by alternatives.
 
 ## Canonical Contributor Agreement
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # spark-test
 
 The main purpose of the `spark-test` library is to provide a seemless, user-friendly interface
-to implement tests for Spark on K8s. `spark-test` provides a number of pytest fixtures 
+to implement tests for Apache Spark on K8s. `spark-test` provides a number of pytest fixtures 
 that allow to create, manage and destroy various kind of resources needed for testing, 
 such as:
 

--- a/python/README.md
+++ b/python/README.md
@@ -72,6 +72,7 @@ such as
 Canonical welcomes contributions to the `spark-test` library. Please check out our [guidelines](./CONTRIBUTING.md) if you're interested in contributing to the solution. Also, if you truly enjoy working on open-source projects like this one and you would like to be part of the OSS revolution, please don't forget to check out the [open positions](https://canonical.com/careers/all) we have at [Canonical](https://canonical.com/).  
 
 ## License
+
 The `spark-test` toolkit is free software, distributed under the Apache Software License, version 2.0. See LICENSE for more information.
 
 See [LICENSE](LICENSE) for more information.

--- a/releases/3.4/yaml/README.md
+++ b/releases/3.4/yaml/README.md
@@ -1,4 +1,4 @@
-# Charmed Spark Kubernetes Bundle
+# Charmed Apache Spark Kubernetes Bundle
 
 ## A fast and fault-tolerant, real-time event streaming platform!
 

--- a/releases/3.4/yaml/metadata.yaml
+++ b/releases/3.4/yaml/metadata.yaml
@@ -4,11 +4,11 @@
 name: spark-k8s-bundle
 display-name: Charmed Kafka
 description: |
-  Spark is an distributed processing engine, designed to scale out your data 
-  analysis and machine learning tasks. This bundles charms to enable a Spark 
+  Apache Spark is an distributed processing engine, designed to scale out your data 
+  analysis and machine learning tasks. This bundles charms to enable a Apache Spark 
   deployment on K8s, featuring integration with object storage, monitoring,
   seamless and integrated configuration.
-summary: Charmed Spark K8s Operator
+summary: Charmed Apache Spark K8s Operator
 docs: https://discourse.charmhub.io/t/charmed-spark-documentation/8963
 source: https://github.com/canonical/spark-k8s-bundle
 issues: https://github.com/canonical/spark-k8s-bundle/issues

--- a/releases/3.5/yaml/README.md
+++ b/releases/3.5/yaml/README.md
@@ -1,4 +1,4 @@
-# Charmed Spark Kubernetes Bundle
+# Charmed Apache Spark Kubernetes Bundle
 
 ## A fast and fault-tolerant, real-time event streaming platform!
 

--- a/releases/3.5/yaml/metadata.yaml
+++ b/releases/3.5/yaml/metadata.yaml
@@ -4,11 +4,11 @@
 name: spark-k8s-bundle
 display-name: Charmed Kafka
 description: |
-  Spark is an distributed processing engine, designed to scale out your data 
-  analysis and machine learning tasks. This bundles charms to enable a Spark 
+  Apache Spark is an distributed processing engine, designed to scale out your data 
+  analysis and machine learning tasks. This bundles charms to enable a Apache Spark 
   deployment on K8s, featuring integration with object storage, monitoring,
   seamless and integrated configuration.
-summary: Charmed Spark K8s Operator
+summary: Charmed Apache Spark K8s Operator
 docs: https://discourse.charmhub.io/t/charmed-spark-documentation/8963
 source: https://github.com/canonical/spark-k8s-bundle
 issues: https://github.com/canonical/spark-k8s-bundle/issues


### PR DESCRIPTION
Add the Terminology section to the CONTRIBUTING.md file.
Fix terminology in Readme files, COntributing.md, and yaml specs.