### PR TITLE
[DPE-6242] Enabling running tests on existing deployments

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -44,7 +44,6 @@ jobs:
           cd python && tox -e unit
 
   integration-tests:
-    if: 'disabled' == 'true'
     name: Integration Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 120

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -105,7 +105,7 @@ jobs:
           tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos
 
       # - name: Setup tmate session
       #   timeout-minutes: 20
@@ -210,7 +210,7 @@ jobs:
           tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
           tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos
 
       # - name: Setup tmate session
       #   timeout-minutes: 20

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -22,16 +22,16 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      # - name: (GitHub hosted) Free up disk space
-      #   timeout-minutes: 5
-      #   run: |
-      #     printf '\nDisk usage before cleanup\n'
-      #     df --human-readable
-      #     # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-      #     rm -r /usr/share/dotnet
-      #     rm -r /opt/hostedtoolcache/
-      #     printf '\nDisk usage after cleanup\n'
-      #     df --human-readable
+      - name: (GitHub hosted) Free up disk space
+        timeout-minutes: 5
+        run: |
+          printf '\nDisk usage before cleanup\n'
+          df --human-readable
+          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          rm -r /usr/share/dotnet
+          rm -r /opt/hostedtoolcache/
+          printf '\nDisk usage after cleanup\n'
+          df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python
@@ -88,9 +88,6 @@ jobs:
       - id: tests-integration
         name: Run Integration Tests
         timeout-minutes: 60
-        # env:
-        #   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-        #   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |    
           cd python 
           
@@ -104,13 +101,9 @@ jobs:
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
+          # We re-run the last tests to make sure that the tests are idempotent
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos
-
-      # - name: Setup tmate session
-      #   timeout-minutes: 20
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3
 
   integration-tests-azure:
     name: Integration Tests (Azure)
@@ -127,16 +120,16 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      # - name: (GitHub hosted) Free up disk space
-      #   timeout-minutes: 5
-      #   run: |
-      #     printf '\nDisk usage before cleanup\n'
-      #     df --human-readable
-      #     # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-      #     rm -r /usr/share/dotnet
-      #     rm -r /opt/hostedtoolcache/
-      #     printf '\nDisk usage after cleanup\n'
-      #     df --human-readable
+      - name: (GitHub hosted) Free up disk space
+        timeout-minutes: 5
+        run: |
+          printf '\nDisk usage before cleanup\n'
+          df --human-readable
+          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          rm -r /usr/share/dotnet
+          rm -r /opt/hostedtoolcache/
+          printf '\nDisk usage after cleanup\n'
+          df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python
@@ -212,10 +205,6 @@ jobs:
           tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
           tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
 
+          # We re-run the last tests to make sure that the tests are idempotent
           tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
           tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos --uuid $UUID
-
-      # - name: Setup tmate session
-      #   timeout-minutes: 20
-      #   if: ${{ failure() }}
-      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   integration-tests:
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ["self-hosted", "linux", "X64", "jammy", "large"]
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -22,16 +22,16 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      - name: (GitHub hosted) Free up disk space
-        timeout-minutes: 5
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /usr/share/dotnet
-          rm -r /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
+      # - name: (GitHub hosted) Free up disk space
+      #   timeout-minutes: 5
+      #   run: |
+      #     printf '\nDisk usage before cleanup\n'
+      #     df --human-readable
+      #     # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+      #     rm -r /usr/share/dotnet
+      #     rm -r /opt/hostedtoolcache/
+      #     printf '\nDisk usage after cleanup\n'
+      #     df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python
@@ -114,7 +114,7 @@ jobs:
 
   integration-tests-azure:
     name: Integration Tests (Azure)
-    runs-on: ubuntu-22.04
+    runs-on: ["self-hosted", "linux", "X64", "jammy", "large"]
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -127,16 +127,16 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      - name: (GitHub hosted) Free up disk space
-        timeout-minutes: 5
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /usr/share/dotnet
-          rm -r /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
+      # - name: (GitHub hosted) Free up disk space
+      #   timeout-minutes: 5
+      #   run: |
+      #     printf '\nDisk usage before cleanup\n'
+      #     df --human-readable
+      #     # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+      #     rm -r /usr/share/dotnet
+      #     rm -r /opt/hostedtoolcache/
+      #     printf '\nDisk usage after cleanup\n'
+      #     df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pip install tox
-          pip install poetry
+          pip install poetry<2.0.0
       - name: Select tests
         id: select-tests
         run: |
@@ -160,7 +160,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pip install tox
-          pip install poetry
+          pip install poetry<2.0.0
       - name: Select tests
         id: select-tests
         run: |

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -102,10 +102,115 @@ jobs:
           tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-spark-job -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-spark-job -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+
+      - name: Setup tmate session
+        timeout-minutes: 20
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
+  integration-tests-azure:
+    name: Integration Tests (Azure)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - --spark-version "3.4.2"
+        backend:
+          - --backend yaml
+        juju:
+          - snap_channel: "3.6/stable"
+            agent: "3.6.0"
+    steps:
+      - name: (GitHub hosted) Free up disk space
+        timeout-minutes: 5
+        run: |
+          printf '\nDisk usage before cleanup\n'
+          df --human-readable
+          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+          rm -r /usr/share/dotnet
+          rm -r /opt/hostedtoolcache/
+          printf '\nDisk usage after cleanup\n'
+          df --human-readable
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - id: setup-python
+        name: Setup Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: "3.10"
+          architecture: x64
+      - name: Get prefsrc
+        run: |
+          echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: ${{ matrix.juju.snap_channel }}
+          provider: microk8s
+          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version ${{ matrix.juju.agent }}"
+          microk8s-group: snap_microk8s
+          microk8s-addons: "rbac dns minio metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
+      - name: Install tox & poetry
+        run: |
+          pip install tox
+          pip install poetry
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - id: setup-terraform
+        name: Install terraform if needed
+        run: |
+          if ! [ -x "$(command -v terraform)" ]; then
+            echo "Installing terraform from snap"
+            sudo snap install terraform --classic 
+          fi
+      - id: cache-image
+        name: Cache Image Locally
+        run: |
+          # Download image for avoiding time out
+          IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0"
+          
+          docker pull $IMAGE 
+          docker save $IMAGE -o image.tar
+          sudo microk8s ctr images import --base-name $IMAGE image.tar
+          docker rmi $IMAGE
+          rm image.tar
+      - id: tests-integration
+        name: Run Integration Tests
+        timeout-minutes: 30
+        env:
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+          AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+        run: |    
+          cd python 
+          
+          # The first tests deploy the bundle
+          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+
+          # Next we only use --no-deploy flag
+          
+          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          
+          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+
+          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
       - name: Setup tmate session
         timeout-minutes: 20

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pip install tox
-          pip install poetry<2.0.0
+          pip install "poetry<2.0.0"
       - name: Select tests
         id: select-tests
         run: |
@@ -160,7 +160,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pip install tox
-          pip install poetry<2.0.0
+          pip install "poetry<2.0.0"
       - name: Select tests
         id: select-tests
         run: |

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -28,7 +28,7 @@ jobs:
           printf '\nDisk usage before cleanup\n'
           df --human-readable
           # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /usr/share/dotnet
+          # rm -r /usr/share/dotnet
           rm -r /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable
@@ -126,7 +126,7 @@ jobs:
           printf '\nDisk usage before cleanup\n'
           df --human-readable
           # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /usr/share/dotnet
+          # rm -r /usr/share/dotnet
           rm -r /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -95,8 +95,10 @@ jobs:
           cd python 
           tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
           
-          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+          
+          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
 
       - name: Setup tmate session
         timeout-minutes: 20

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -87,7 +87,7 @@ jobs:
           rm image.tar
       - id: tests-integration
         name: Run Integration Tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         # env:
         #   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
         #   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
@@ -107,10 +107,10 @@ jobs:
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           tox run -e integration-sparkjob -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
-      - name: Setup tmate session
-        timeout-minutes: 20
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   timeout-minutes: 20
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
 
   integration-tests-azure:
     name: Integration Tests (Azure)
@@ -192,7 +192,7 @@ jobs:
           rm image.tar
       - id: tests-integration
         name: Run Integration Tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
@@ -212,7 +212,7 @@ jobs:
           tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
-      - name: Setup tmate session
-        timeout-minutes: 20
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   timeout-minutes: 20
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -22,16 +22,6 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      - name: (GitHub hosted) Free up disk space
-        timeout-minutes: 5
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          # rm -r /usr/share/dotnet
-          rm -r /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python
@@ -120,16 +110,6 @@ jobs:
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
     steps:
-      - name: (GitHub hosted) Free up disk space
-        timeout-minutes: 5
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          # rm -r /usr/share/dotnet
-          rm -r /opt/hostedtoolcache/
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
       - name: Checkout repo
         uses: actions/checkout@v4
       - id: setup-python

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -102,7 +102,10 @@ jobs:
           tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
           
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-spark-job -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+
           tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-spark-job -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
       - name: Setup tmate session
         timeout-minutes: 20

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -93,12 +93,16 @@ jobs:
         #   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |    
           cd python 
-          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
           
+          # The first tests deploy the bundle
           tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+
+          # Next we only use --no-deploy flag
           
-          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
-          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          
+          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
 
       - name: Setup tmate session
         timeout-minutes: 20

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -1,98 +1,26 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: Run Tests
+name: Mimic UAT Tests
 
 on:
-  schedule:
-    - cron: '53 0 * * *' # Daily at 00:53 UTC
-  workflow_call:
+  pull_request:
 
 jobs:
-  checks:
-    uses: ./.github/workflows/ci-checks.yaml
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version:
-          # - '3.9'
-          - '3.10'
-    needs:
-      - checks
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - id: setup-python
-        name: Setup Python
-        uses: actions/setup-python@v5.0.0
-        with:
-          python-version: ${{matrix.python-version}}
-          architecture: x64
-      - name: Install tox & poetry
-        run: |
-          pip install tox
-          pip install "poetry<2.0.0"
-      - id: tests-unit
-        name: Run Unittests
-        run: |
-          cd python && tox -e unit
-
   integration-tests:
-    if: 'disabled' == 'true'
     name: Integration Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     strategy:
-      max-parallel: 7
       fail-fast: false
       matrix:
         version:
           - --spark-version "3.4.2"
-          - --spark-version "3.5.1"
         backend:
           - --backend yaml
-          - --backend terraform
-        cos:
-          -
-          - --cos-model cos
-        tox-environments:
-          - integration-basic
-          - integration-sparkjob
-          - integration-sparkjob-azure
-          - integration-bundle
-          - integration-kyuubi
-          - integration-kyuubi-azure
         juju:
-          - snap_channel: "3.4/stable"
-            agent: "3.4.2"
           - snap_channel: "3.6/stable"
             agent: "3.6.0"
-        exclude:
-          - tox-environments: integration-basic           # Basic tests, test without COS
-            cos: --cos-model cos
-          - tox-environments: integration-basic           # Basic tests, test without terraform
-            backend: --backend terraform
-          - tox-environments: integration-sparkjob        # COS is mandatory for the sparkjob test
-            cos: 
-          - tox-environments: integration-sparkjob-azure  # COS is mandatory for the sparkjob test
-            cos: 
-          - tox-environments: integration-sparkjob-azure  # Azure tests only supported in YAML bundle at the moment
-            backend: --backend terraform
-          - tox-environments: integration-kyuubi          # Kyuubi tests do not require COS  
-            cos: --cos-model cos
-          - tox-environments: integration-kyuubi-azure    # Kyuubi tests do not require COS
-            cos: --cos-model cos
-          - tox-environments: integration-kyuubi-azure    # Azure tests only supported in YAML bundle at the moment
-            backend: --backend terraform
-    needs:
-      - checks
-      - unit-tests
     steps:
       - name: (GitHub hosted) Free up disk space
         timeout-minutes: 5
@@ -127,7 +55,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pip install tox
-          pip install "poetry<2.0.0"
+          pip install poetry
       - name: Select tests
         id: select-tests
         run: |
@@ -160,11 +88,16 @@ jobs:
       - id: tests-integration
         name: Run Integration Tests
         timeout-minutes: 30
-        env:
-          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
-          AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+        # env:
+        #   AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
+        #   AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |    
-          cd python && tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' ${{ matrix.backend }} ${{ matrix.cos }} ${{ matrix.version }} --keep-models
+          cd python 
+          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+          
+          tox run -e integration-bundle -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-kyuubi -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+
       - name: Setup tmate session
         timeout-minutes: 20
         if: ${{ failure() }}

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -197,20 +197,23 @@ jobs:
           AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
           AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
         run: |    
-          cd python 
+          UUID=$(uuidgen)
+          echo "Using UUID: ${UUID}"
+          
+          cd python
           
           # The first tests deploy the bundle
-          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos
+          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --keep-models --model test-uat --cos-model cos --uuid $UUID
 
           # Next we only use --no-deploy flag
           
-          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-bundle-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
           
-          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
+          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
+          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
 
-          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos
-          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos
+          tox run -e integration-kyuubi-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --keep-models --model test-uat --cos-model cos --uuid $UUID
+          tox run -e integration-sparkjob-azure -- ${{ matrix.backend }} ${{ matrix.version }} --no-deploy --model test-uat --cos-model cos --uuid $UUID
 
       # - name: Setup tmate session
       #   timeout-minutes: 20

--- a/python/spark_test/core/azure_storage.py
+++ b/python/spark_test/core/azure_storage.py
@@ -59,8 +59,6 @@ class Container:
 
         return Container(client, container_name, credentials)
 
-
-
     @classmethod
     def create(cls, container_name: str, credentials: Credentials):
         """Create and return an instance of the Container class.

--- a/python/spark_test/core/azure_storage.py
+++ b/python/spark_test/core/azure_storage.py
@@ -42,6 +42,26 @@ class Container:
         self.credentials = credentials
 
     @classmethod
+    def get(cls, container_name: str, credentials: Credentials):
+        """Return an instance of an existing Container class.
+
+        Args:
+            container_name: name of the container
+            credentials: Azure Storage credentials
+
+        Returns:
+            Container object
+        """
+        client = BlobServiceClient.from_connection_string(credentials.connection_string)
+
+        if not cls._exists(container_name, client):
+            raise FileNotFoundError(f"Bucket {container_name} does not exist.")
+
+        return Container(client, container_name, credentials)
+
+
+
+    @classmethod
     def create(cls, container_name: str, credentials: Credentials):
         """Create and return an instance of the Container class.
 
@@ -55,7 +75,7 @@ class Container:
         client = BlobServiceClient.from_connection_string(credentials.connection_string)
 
         if cls._exists(container_name, client):
-            raise ValueError(
+            raise FileExistsError(
                 f"Cannot create container {container_name}. Already exists."
             )
 

--- a/python/spark_test/core/pod.py
+++ b/python/spark_test/core/pod.py
@@ -45,11 +45,14 @@ class Pod:
 
     def write(self, filename):
         with open(filename, "w") as fid:
-            json.dump({
-                "pod_name": self.pod_name,
-                "namespace": self.namespace,
-                "kubeconfig_file": str(self.kubeconfig_file)
-            }, fid)
+            json.dump(
+                {
+                    "pod_name": self.pod_name,
+                    "namespace": self.namespace,
+                    "kubeconfig_file": str(self.kubeconfig_file),
+                },
+                fid,
+            )
 
     @classmethod
     def load(cls, filename):

--- a/python/spark_test/core/pod.py
+++ b/python/spark_test/core/pod.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+import json
 import subprocess
 from functools import cached_property
 from pathlib import Path
@@ -42,6 +42,21 @@ class Pod:
         self.pod_name = pod_name
         self.namespace = namespace
         self.kubeconfig_file = kubeconfig_file
+
+    def write(self, filename):
+        with open(filename, "w") as fid:
+            json.dump({
+                "pod_name": self.pod_name,
+                "namespace": self.namespace,
+                "kubeconfig_file": str(self.kubeconfig_file)
+            }, fid)
+
+    @classmethod
+    def load(cls, filename):
+        with open(filename, "r") as fid:
+            data = json.load(fid)
+        data["kubeconfig_file"] = Path(data["kubeconfig_file"])
+        return cls(**data)
 
     def exec(self, cmd: List[str], envs: Dict[str, str] | None = None):
         """Execute a command on the pod.

--- a/python/spark_test/core/s3.py
+++ b/python/spark_test/core/s3.py
@@ -52,8 +52,8 @@ class Bucket:
 
         config = Config(connect_timeout=60, retries={"max_attempts": 0})
         session = boto3.session.Session(
-            aws_access_key_id = credentials.access_key,
-            aws_secret_access_key = credentials.secret_key,
+            aws_access_key_id=credentials.access_key,
+            aws_secret_access_key=credentials.secret_key,
         )
 
         s3 = session.client("s3", endpoint_url=credentials.endpoint, config=config)
@@ -84,7 +84,9 @@ class Bucket:
         s3 = session.client("s3", endpoint_url=credentials.endpoint, config=config)
 
         if cls._exists(bucket_name, s3):
-            raise FileExistsError(f"Cannot create bucket {bucket_name}. Already exists.")
+            raise FileExistsError(
+                f"Cannot create bucket {bucket_name}. Already exists."
+            )
 
         s3.create_bucket(Bucket=bucket_name)
 

--- a/python/spark_test/fixtures/azure_storage.py
+++ b/python/spark_test/fixtures/azure_storage.py
@@ -29,7 +29,7 @@ def container(ops_test, azure_credentials, container_name):
         _container = Container.create(container_name, azure_credentials)
         _container.init()
     except FileExistsError:
-        _bucket = Container.get(container_name, azure_credentials)
+        _container = Container.get(container_name, azure_credentials)
 
     yield _container
 

--- a/python/spark_test/fixtures/azure_storage.py
+++ b/python/spark_test/fixtures/azure_storage.py
@@ -24,8 +24,14 @@ def container_name():
 
 
 @pytest.fixture(scope="module")
-def container(azure_credentials, container_name):
-    _container = Container.create(container_name, azure_credentials)
-    _container.init()
+def container(ops_test, azure_credentials, container_name):
+    try:
+        _container = Container.create(container_name, azure_credentials)
+        _container.init()
+    except FileExistsError:
+        _bucket = Container.get(container_name, azure_credentials)
+
     yield _container
-    _container.delete()
+
+    if not ops_test.keep_model:
+        _container.delete()

--- a/python/spark_test/fixtures/s3.py
+++ b/python/spark_test/fixtures/s3.py
@@ -36,10 +36,14 @@ def bucket_name():
 
 
 @pytest.fixture(scope="module")
-def bucket(credentials, bucket_name):
-    _bucket = Bucket.create(bucket_name, credentials)
+def bucket(ops_test, credentials, bucket_name):
+    try:
+        _bucket = Bucket.create(bucket_name, credentials)
+        _bucket.init()
+    except FileExistsError:
+        _bucket = Bucket.get(bucket_name, credentials)
 
-    _bucket.init()
     yield _bucket
 
-    _bucket.delete()
+    if not ops_test.keep_model:
+        _bucket.delete()

--- a/python/spark_test/fixtures/service_account.py
+++ b/python/spark_test/fixtures/service_account.py
@@ -17,7 +17,8 @@ def _clearnup_registry(registry):
 def registry(interface):
     registry = K8sServiceAccountRegistry(interface)
     yield registry
-    _clearnup_registry(registry)
+
+    # _clearnup_registry(registry)
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -82,6 +82,12 @@ def pytest_addoption(parser):
         type=str,
         help="Which Spark version to use for bundle testing.",
     )
+    parser.addoption(
+        "--uuid",
+        default=uuid.uuid4(),
+        type=str,
+        help="Which Spark version to use for bundle testing.",
+    )
 
 
 @pytest.fixture(scope="module")
@@ -100,6 +106,12 @@ def backend(request) -> None | str:
 def spark_version(request) -> str:
     """The backend which is to be used to deploy the bundle."""
     return request.config.getoption("--spark-version") or "3.4.2"
+
+
+@pytest.fixture(scope="module")
+def test_uuid(request) -> str:
+    """The backend which is to be used to deploy the bundle."""
+    return request.config.getoption("--uuid") or uuid.uuid4()
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -260,11 +260,12 @@ async def cos(ops_test: OpsTest, cos_model):
             await ops_test.forget_model(cos_model)
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def spark_bundle(ops_test: OpsTest, credentials, bucket, bundle, cos):
     """Deploy all applications in the Kyuubi bundle, wait for all of them to be active,
     and finally yield a list of the names of the applications that were deployed.
     """
+
     applications = await (
         deploy_bundle_yaml(bundle, bucket, cos, ops_test)
         if isinstance(bundle, Bundle)
@@ -305,7 +306,7 @@ async def spark_bundle(ops_test: OpsTest, credentials, bucket, bundle, cos):
     yield applications
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def spark_bundle_with_azure_storage(
     ops_test: OpsTest,
     azure_credentials: AzureStorageCredentials,

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -209,7 +209,9 @@ async def cos(ops_test: OpsTest, cos_model):
     """
     Deploy COS bundle depending upon the value of cos_model fixture, and yield its value.
     """
-    if cos_model and cos_model not in ops_test.models:
+    existing_models = await ops_test._controller.list_models()
+
+    if cos_model and cos_model not in existing_models:
 
         base_url = (
             "https://raw.githubusercontent.com/canonical/cos-lite-bundle/main/overlays"

--- a/python/tests/integration/test_bundle.py
+++ b/python/tests/integration/test_bundle.py
@@ -43,7 +43,6 @@ async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
     for app_name in ops_test.model.applications:

--- a/python/tests/integration/test_bundle.py
+++ b/python/tests/integration/test_bundle.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import logging
 
 import pytest
@@ -35,10 +36,15 @@ def namespace(namespace_name):
     return namespace_name
 
 
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_deploy_bundle(ops_test, spark_bundle):
+async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
-    async for applications in spark_bundle:
-        for app_name in applications:
-            assert ops_test.model.applications[app_name].status == "active"
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"

--- a/python/tests/integration/test_bundle_azure.py
+++ b/python/tests/integration/test_bundle_azure.py
@@ -5,25 +5,20 @@
 
 import asyncio
 import logging
+import uuid
 
 import pytest
 from pytest_operator.plugin import OpsTest
 
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
-from spark_test.fixtures.s3 import bucket, credentials
 from spark_test.fixtures.service_account import registry, service_account
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def bucket_name():
-    return "spark-bucket"
-
-
-@pytest.fixture
-def pod_name():
-    return "my-testpod"
+def container_name():
+    return f"spark-container-{uuid.uuid4()}"
 
 
 @pytest.fixture(scope="module")
@@ -35,6 +30,9 @@ def namespace_name(ops_test: OpsTest):
 def namespace(namespace_name):
     return namespace_name
 
+@pytest.fixture
+def pod_name():
+    return "my-testpod"
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail

--- a/python/tests/integration/test_bundle_azure.py
+++ b/python/tests/integration/test_bundle_azure.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container"
+    return "spark-container"
 
 
 @pytest.fixture(scope="module")
@@ -30,9 +30,11 @@ def namespace_name(ops_test: OpsTest):
 def namespace(namespace_name):
     return namespace_name
 
+
 @pytest.fixture
 def pod_name():
     return "my-testpod"
+
 
 @pytest.mark.skip_if_deployed
 @pytest.mark.abort_on_fail

--- a/python/tests/integration/test_bundle_azure.py
+++ b/python/tests/integration/test_bundle_azure.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def container_name():
-    return "spark-container"
+def container_name(test_uuid):
+    return f"spark-container-{test_uuid}"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/test_bundle_azure.py
+++ b/python/tests/integration/test_bundle_azure.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container-{uuid.uuid4()}"
+    return f"spark-container"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/test_bundle_azure.py
+++ b/python/tests/integration/test_bundle_azure.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
+from spark_test.fixtures.s3 import bucket, credentials
+from spark_test.fixtures.service_account import registry, service_account
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def bucket_name():
+    return "spark-bucket"
+
+
+@pytest.fixture
+def pod_name():
+    return "my-testpod"
+
+
+@pytest.fixture(scope="module")
+def namespace_name(ops_test: OpsTest):
+    return ops_test.model_name
+
+
+@pytest.fixture(scope="module")
+def namespace(namespace_name):
+    return namespace_name
+
+
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle_with_azure_storage):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
+@pytest.mark.abort_on_fail
+async def test_active_status(ops_test):
+    """Test whether the bundle has deployed successfully."""
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import logging
 
 import psycopg2
@@ -45,13 +46,18 @@ def namespace(namespace_name):
     return namespace_name
 
 
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_deploy_bundle(ops_test, spark_bundle):
+async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
-    async for applications in spark_bundle:
-        for app_name in applications:
-            assert ops_test.model.applications[app_name].status == "active"
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"
 
 
 @pytest.mark.asyncio
@@ -83,6 +89,9 @@ async def test_jdbc_endpoint(ops_test: OpsTest):
     # Create a database
     db = client.get_database(db_name)
     assert db_name in client.databases
+
+    if table_name in db.tables:
+        db.get_table(table_name).drop()
 
     table = db.create_table(
         table_name, [("name", str), ("country", str), ("year_birth", int)]
@@ -209,3 +218,16 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
                 "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
                 for timestamp, message in logs.items()
             )
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.asyncio
+async def test_drop_table_if_exists(ops_test: OpsTest):
+    credentials = await get_kyuubi_credentials(ops_test, "kyuubi")
+    client = KyuubiClient(**credentials)
+
+    db_name, table_name = "spark_test", "my_table"
+
+    db = client.get_database(db_name)
+    db.get_table(table_name).drop()
+    db.drop()

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -198,17 +198,11 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
             # check for non empty logs
             assert len(logs) > 0
 
-            # check if startup message is there...
-            # assert any(
-            #     "Starting org.apache.kyuubi.server.KyuubiServer" in message
-            #     for timestamp, message in logs.items()
-            # )
-
             # check if Kyuubi related logs are there...
-            # assert any(
-            #     "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
-            #     for timestamp, message in logs.items()
-            # )
+            assert any(
+                "org.apache.kyuubi.session.KyuubiSessionImpl:" in message
+                for timestamp, message in logs.items()
+            )
 
 
 @pytest.mark.abort_on_fail

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -90,9 +90,6 @@ async def test_jdbc_endpoint(ops_test: OpsTest):
     db = client.get_database(db_name)
     assert db_name in client.databases
 
-    if table_name in db.tables:
-        db.get_table(table_name).drop()
-
     table = db.create_table(
         table_name, [("name", str), ("country", str), ("year_birth", int)]
     )
@@ -202,22 +199,22 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
                 KYUUBI_APP_NAME,
                 5000,
             )
-            logger.info(f"Retrieved logs: {logs}")
+            logger.debug(f"Retrieved logs: {logs}")
 
             # check for non empty logs
             assert len(logs) > 0
 
             # check if startup message is there...
-            assert any(
-                "Starting org.apache.kyuubi.server.KyuubiServer" in message
-                for timestamp, message in logs.items()
-            )
+            # assert any(
+            #     "Starting org.apache.kyuubi.server.KyuubiServer" in message
+            #     for timestamp, message in logs.items()
+            # )
 
             # check if Kyuubi related logs are there...
-            assert any(
-                "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
-                for timestamp, message in logs.items()
-            )
+            # assert any(
+            #     "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
+            #     for timestamp, message in logs.items()
+            # )
 
 
 @pytest.mark.abort_on_fail

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -53,14 +53,12 @@ async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
     for app_name in ops_test.model.applications:
         assert ops_test.model.applications[app_name].status == "active"
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_authentication_is_enforced(ops_test):
     """Test that the authentication has been enabled in the bundle by default
@@ -77,7 +75,6 @@ async def test_authentication_is_enforced(ops_test):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_jdbc_endpoint(ops_test: OpsTest):
     """Test that JDBC connection in Kyuubi works out of the box in bundle."""
 
@@ -101,7 +98,6 @@ async def test_jdbc_endpoint(ops_test: OpsTest):
     assert len(list(table.rows())) == 3
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_postgresql_metastore_is_used(ops_test: OpsTest):
     "Test that PostgreSQL metastore is being used by Kyuubi in the bundle."
@@ -130,7 +126,6 @@ async def test_postgresql_metastore_is_used(ops_test: OpsTest):
     assert num_tables != 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_ha_deployment(ops_test: OpsTest):
     active_servers = await get_active_kyuubi_servers_list(ops_test)
@@ -145,7 +140,6 @@ async def test_ha_deployment(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")
@@ -218,7 +212,6 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_drop_table_if_exists(ops_test: OpsTest):
     credentials = await get_kyuubi_credentials(ops_test, "kyuubi")
     client = KyuubiClient(**credentials)

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -55,14 +55,12 @@ async def test_deploy_bundle(ops_test: OpsTest, spark_bundle_with_azure_storage)
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
     for app_name in ops_test.model.applications:
         assert ops_test.model.applications[app_name].status == "active"
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_authentication_is_enforced(ops_test):
     """Test that the authentication has been enabled in the bundle by default
@@ -79,7 +77,6 @@ async def test_authentication_is_enforced(ops_test):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_jdbc_endpoint(ops_test: OpsTest):
     """Test that JDBC connection in Kyuubi works out of the box in bundle."""
 
@@ -103,7 +100,6 @@ async def test_jdbc_endpoint(ops_test: OpsTest):
     assert len(list(table.rows())) == 3
 
 
-@pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_postgresql_metastore_is_used(ops_test: OpsTest):
     "Test that PostgreSQL metastore is being used by Kyuubi in the bundle."
@@ -133,7 +129,6 @@ async def test_postgresql_metastore_is_used(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -182,19 +182,30 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
                 KYUUBI_APP_NAME,
                 5000,
             )
-            logger.info(f"Retrieved logs: {logs}")
+            logger.debug(f"Retrieved logs: {logs}")
 
             # check for non empty logs
             assert len(logs) > 0
 
-            # check if startup message is there...
-            assert any(
-                "Starting org.apache.kyuubi.server.KyuubiServer" in message
-                for timestamp, message in logs.items()
-            )
+            # # check if startup message is there...
+            # assert any(
+            #     "Starting org.apache.kyuubi.server.KyuubiServer" in message
+            #     for timestamp, message in logs.items()
+            # )
+            #
+            # # check if Kyuubi related logs are there...
+            # assert any(
+            #     "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
+            #     for timestamp, message in logs.items()
+            # )
 
-            # check if Kyuubi related logs are there...
-            assert any(
-                "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
-                for timestamp, message in logs.items()
-            )
+@pytest.mark.abort_on_fail
+async def test_drop_table_if_exists(ops_test: OpsTest):
+    credentials = await get_kyuubi_credentials(ops_test, "kyuubi")
+    client = KyuubiClient(**credentials)
+
+    db_name, table_name = "spark_test", "my_table"
+
+    db = client.get_database(db_name)
+    db.get_table(table_name).drop()
+    db.drop()

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import logging
 import uuid
 
@@ -47,13 +48,18 @@ def namespace(namespace_name):
     return namespace_name
 
 
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle_with_azure_storage):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_deploy_bundle(ops_test, spark_bundle_with_azure_storage):
+async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
-    async for applications in spark_bundle_with_azure_storage:
-        for app_name in applications:
-            assert ops_test.model.applications[app_name].status == "active"
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"
 
 
 @pytest.mark.asyncio

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -33,8 +33,8 @@ KYUUBI_APP_NAME = "kyuubi"
 
 
 @pytest.fixture(scope="module")
-def container_name():
-    return "spark-container"
+def container_name(test_uuid):
+    return f"spark-container-{test_uuid}"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -186,17 +186,12 @@ async def test_kyuubi_metrics_in_cos(ops_test: OpsTest, cos):
             # check for non empty logs
             assert len(logs) > 0
 
-            # # check if startup message is there...
-            # assert any(
-            #     "Starting org.apache.kyuubi.server.KyuubiServer" in message
-            #     for timestamp, message in logs.items()
-            # )
-            #
-            # # check if Kyuubi related logs are there...
-            # assert any(
-            #     "INFO main org.apache.kyuubi.server.KyuubiServer:" in message
-            #     for timestamp, message in logs.items()
-            # )
+            # check if Kyuubi related logs are there...
+            assert any(
+                "org.apache.kyuubi.session.KyuubiSessionImpl:" in message
+                for timestamp, message in logs.items()
+            )
+
 
 @pytest.mark.abort_on_fail
 async def test_drop_table_if_exists(ops_test: OpsTest):

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -14,7 +14,6 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from spark_test.core.kyuubi import KyuubiClient
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
-from spark_test.fixtures.s3 import bucket, credentials
 
 from .helpers import (
     construct_azure_resource_uri,

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -34,7 +34,7 @@ KYUUBI_APP_NAME = "kyuubi"
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container-{uuid.uuid4()}"
+    return f"spark-container"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/test_kyuubi_azure.py
+++ b/python/tests/integration/test_kyuubi_azure.py
@@ -34,7 +34,7 @@ KYUUBI_APP_NAME = "kyuubi"
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container"
+    return "spark-container"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/test_spark_job.py
+++ b/python/tests/integration/test_spark_job.py
@@ -67,7 +67,6 @@ async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
     for app_name in ops_test.model.applications:
@@ -80,7 +79,6 @@ def spark_properties(small_profile_properties, image_properties):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_run_job(
     ops_test: OpsTest,
     registry,
@@ -127,7 +125,6 @@ async def test_run_job(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_logs_are_persisted(
     ops_test: OpsTest, registry, service_account, credentials, bucket
 ):
@@ -162,7 +159,6 @@ async def test_job_logs_are_persisted(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_in_history_server(
     ops_test: OpsTest,
 ):
@@ -199,7 +195,6 @@ async def test_job_in_history_server(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")
@@ -236,7 +231,6 @@ async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_spark_metrics_in_prometheus(
     ops_test: OpsTest, registry, service_account, cos
 ):
@@ -275,7 +269,6 @@ async def test_spark_metrics_in_prometheus(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_spark_logforwaring_to_loki(
     ops_test: OpsTest, registry, service_account, cos
 ):
@@ -292,7 +285,6 @@ async def test_spark_logforwaring_to_loki(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_history_server_metrics_in_cos(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")

--- a/python/tests/integration/test_spark_job.py
+++ b/python/tests/integration/test_spark_job.py
@@ -10,7 +10,7 @@ from spark8t.domain import PropertyFile
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
-from spark_test.fixtures.pod import pod, Pod
+from spark_test.fixtures.pod import Pod, pod
 from spark_test.fixtures.s3 import bucket, credentials
 from spark_test.fixtures.service_account import (
     registry,
@@ -77,9 +77,11 @@ async def test_active_status(ops_test):
 def spark_properties(small_profile_properties, image_properties):
     return small_profile_properties + image_properties
 
+
 @pytest.fixture(scope="module")
 def tmp_folder(tmp_path_factory):
     return tmp_path_factory.mktemp("data")
+
 
 @pytest.mark.abort_on_fail
 async def test_run_job(
@@ -104,7 +106,9 @@ async def test_run_job(
 
     initial_driver_pods = set(
         pod.pod_name
-        for pod in get_spark_drivers(registry.kube_interface.client, service_account.namespace)
+        for pod in get_spark_drivers(
+            registry.kube_interface.client, service_account.namespace
+        )
     )
 
     pod.exec(
@@ -125,11 +129,7 @@ async def test_run_job(
     )
     assert len(driver_pods) == len(initial_driver_pods) + 1
 
-    driver_pod = [
-        pod
-        for pod in driver_pods
-        if pod.pod_name not in initial_driver_pods
-    ]
+    driver_pod = [pod for pod in driver_pods if pod.pod_name not in initial_driver_pods]
 
     assert len(driver_pod) == 1
 
@@ -146,8 +146,8 @@ async def test_run_job(
 
 @pytest.mark.abort_on_fail
 async def test_job_logs_are_persisted(
-        ops_test: OpsTest, registry, service_account, credentials, bucket, tmp_folder
-    ):
+    ops_test: OpsTest, registry, service_account, credentials, bucket, tmp_folder
+):
 
     driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
 
@@ -177,9 +177,7 @@ async def test_job_logs_are_persisted(
 
 
 @pytest.mark.abort_on_fail
-async def test_job_in_history_server(
-    ops_test: OpsTest, tmp_folder
-):
+async def test_job_in_history_server(ops_test: OpsTest, tmp_folder):
     driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
 
     # check that spark-history server contains the application entry
@@ -285,8 +283,7 @@ async def test_spark_metrics_in_prometheus(
 
         logger.info(f"query: {query}")
         spark_ids = [
-            result["metric"]["exported_job"]
-            for result in query["data"]["result"]
+            result["metric"]["exported_job"] for result in query["data"]["result"]
         ]
         logger.info(f"Spark ids: {spark_ids}")
 

--- a/python/tests/integration/test_spark_job.py
+++ b/python/tests/integration/test_spark_job.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -59,13 +60,18 @@ def namespace(namespace_name):
     return namespace_name
 
 
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_deploy_bundle(ops_test, spark_bundle):
+async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
-    async for applications in spark_bundle:
-        for app_name in applications:
-            assert ops_test.model.applications[app_name].status == "active"
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"
 
 
 @pytest.fixture

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -12,7 +12,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from spark_test.fixtures.azure_storage import azure_credentials, container
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
-from spark_test.fixtures.pod import pod, Pod
+from spark_test.fixtures.pod import Pod, pod
 from spark_test.fixtures.service_account import (
     registry,
     service_account,
@@ -44,7 +44,7 @@ LOKI = "loki"
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container"
+    return "spark-container"
 
 
 @pytest.fixture
@@ -79,13 +79,21 @@ async def test_active_status(ops_test):
 def spark_properties(small_profile_properties, image_properties):
     return small_profile_properties + image_properties
 
+
 @pytest.fixture(scope="module")
 def tmp_folder(tmp_path_factory):
     return tmp_path_factory.mktemp("data")
 
+
 @pytest.mark.abort_on_fail
 async def test_run_job(
-    ops_test: OpsTest, registry, service_account, pod, container, spark_properties, tmp_folder
+    ops_test: OpsTest,
+    registry,
+    service_account,
+    pod,
+    container,
+    spark_properties,
+    tmp_folder,
 ):
     """Run a spark job."""
 
@@ -101,7 +109,9 @@ async def test_run_job(
 
     initial_driver_pods = set(
         pod.pod_name
-        for pod in get_spark_drivers(registry.kube_interface.client,service_account.namespace)
+        for pod in get_spark_drivers(
+            registry.kube_interface.client, service_account.namespace
+        )
     )
 
     pod.exec(
@@ -124,11 +134,7 @@ async def test_run_job(
 
     assert len(driver_pods) == len(initial_driver_pods) + 1
 
-    driver_pod = [
-        pod
-        for pod in driver_pods
-        if pod.pod_name not in initial_driver_pods
-    ]
+    driver_pod = [pod for pod in driver_pods if pod.pod_name not in initial_driver_pods]
 
     logger.info(f"Driver pod: {driver_pod[0].pod_name}")
     logger.info("\n".join(driver_pod[0].logs()))
@@ -172,9 +178,7 @@ async def test_job_logs_are_persisted(
 
 
 @pytest.mark.abort_on_fail
-async def test_job_in_history_server(
-    ops_test: OpsTest, tmp_folder
-):
+async def test_job_in_history_server(ops_test: OpsTest, tmp_folder):
     driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
 
     # check that spark-history server contains the application entry
@@ -251,7 +255,9 @@ async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
 
 
 @pytest.mark.abort_on_fail
-async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, cos, tmp_folder):
+async def test_job_in_prometheus(
+    ops_test: OpsTest, registry, service_account, cos, tmp_folder
+):
     if not cos:
         pytest.skip("Not possible to test without cos")
 
@@ -276,8 +282,7 @@ async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, c
 
         logger.info(f"query: {query}")
         spark_ids = [
-            result["metric"]["exported_job"]
-            for result in query["data"]["result"]
+            result["metric"]["exported_job"] for result in query["data"]["result"]
         ]
         logger.info(f"Spark ids: {spark_ids}")
 

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -43,8 +43,8 @@ LOKI = "loki"
 
 
 @pytest.fixture(scope="module")
-def container_name():
-    return "spark-container"
+def container_name(test_uuid):
+    return f"spark-container-{test_uuid}"
 
 
 @pytest.fixture

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -61,13 +62,18 @@ def namespace(namespace_name):
     return namespace_name
 
 
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy_bundle(ops_test: OpsTest, spark_bundle_with_azure_storage):
+    await asyncio.sleep(0)  # do nothing, await deploy_cluster
+
+
 @pytest.mark.abort_on_fail
 @pytest.mark.asyncio
-async def test_deploy_bundle(ops_test, spark_bundle_with_azure_storage):
+async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
-    async for applications in spark_bundle_with_azure_storage:
-        for app_name in applications:
-            assert ops_test.model.applications[app_name].status == "active"
+    for app_name in ops_test.model.applications:
+        assert ops_test.model.applications[app_name].status == "active"
 
 
 @pytest.fixture

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -12,7 +12,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from spark_test.fixtures.azure_storage import azure_credentials, container
 from spark_test.fixtures.k8s import envs, interface, kubeconfig, namespace
-from spark_test.fixtures.pod import pod
+from spark_test.fixtures.pod import pod, Pod
 from spark_test.fixtures.service_account import (
     registry,
     service_account,
@@ -79,10 +79,13 @@ async def test_active_status(ops_test):
 def spark_properties(small_profile_properties, image_properties):
     return small_profile_properties + image_properties
 
+@pytest.fixture(scope="module")
+def tmp_folder(tmp_path_factory):
+    return tmp_path_factory.mktemp("data")
 
 @pytest.mark.abort_on_fail
 async def test_run_job(
-    ops_test: OpsTest, registry, service_account, pod, container, spark_properties
+    ops_test: OpsTest, registry, service_account, pod, container, spark_properties, tmp_folder
 ):
     """Run a spark job."""
 
@@ -95,6 +98,11 @@ async def test_run_job(
     script_uri = construct_azure_resource_uri(container, "spark_test.py")
 
     registry.set_configurations(service_account.id, spark_properties)
+
+    initial_driver_pods = set(
+        pod.pod_name
+        for pod in get_spark_drivers(registry.kube_interface.client,service_account.namespace)
+    )
 
     pod.exec(
         [
@@ -113,41 +121,47 @@ async def test_run_job(
     driver_pods = get_spark_drivers(
         registry.kube_interface.client, service_account.namespace
     )
-    assert len(driver_pods) == 1
 
-    logger.info(f"Driver pod: {driver_pods[0].pod_name}")
-    logger.info("\n".join(driver_pods[0].logs()))
+    assert len(driver_pods) == len(initial_driver_pods) + 1
 
-    line_check = filter(lambda line: "Number of lines" in line, driver_pods[0].logs())
+    driver_pod = [
+        pod
+        for pod in driver_pods
+        if pod.pod_name not in initial_driver_pods
+    ]
+
+    logger.info(f"Driver pod: {driver_pod[0].pod_name}")
+    logger.info("\n".join(driver_pod[0].logs()))
+
+    line_check = filter(lambda line: "Number of lines" in line, driver_pod[0].logs())
 
     assert next(line_check)
+
+    # write out spark_job_id to be used elsewhere
+    driver_pod[0].write(tmp_folder / "spark-job-driver.json")
 
 
 @pytest.mark.abort_on_fail
 async def test_job_logs_are_persisted(
-    ops_test: OpsTest, registry, service_account, container
+    ops_test: OpsTest, registry, service_account, container, tmp_folder
 ):
+    driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
+
+    # Test that logs are persisted in S3
     integration_hub_conf = get_secret_data(
         service_account.namespace, service_account.name
     )
     logger.info(f"Integration Hub confs: {integration_hub_conf}")
 
-    # check that logs are in s3 folder
-    driver_pods = get_spark_drivers(
-        registry.kube_interface.client, service_account.namespace
-    )
-    assert len(driver_pods) == 1
     confs = registry.get(service_account.id).configurations
     logger.info(f"Configurations: {confs.props}")
     azure_storage_folder = confs.props["spark.eventLog.dir"]
     logger.info(f"Log folder: {azure_storage_folder}")
     logger.info(f"Azure storage blobs: {container.list_blobs()}")
-    driver_pod_name = driver_pods[0].pod_name
-    logger.info(f"Pod name: {driver_pod_name}")
 
-    logger.info(f"metadata: {driver_pods[0].metadata}")
+    logger.info(f"metadata: {driver_pod.metadata}")
 
-    spark_app_selector = driver_pods[0].labels["spark-app-selector"]
+    spark_app_selector = driver_pod.labels["spark-app-selector"]
 
     logs_discovered = False
     for obj in container.list_blobs():
@@ -159,8 +173,10 @@ async def test_job_logs_are_persisted(
 
 @pytest.mark.abort_on_fail
 async def test_job_in_history_server(
-    ops_test: OpsTest,
+    ops_test: OpsTest, tmp_folder
 ):
+    driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
+
     # check that spark-history server contains the application entry
     status = await ops_test.model.get_status()
 
@@ -174,14 +190,19 @@ async def test_job_in_history_server(
 
     logger.info(f"Show unit: {stdout}")
 
+    spark_id = driver_pod.labels["spark-app-selector"]
+    logger.info(f"Spark ID: {spark_id}")
+
     for i in range(0, 5):
         try:
             logger.info(f"try n#{i} time: {time.time()}")
-            apps = json.loads(
+            raw_apps = json.loads(
                 urllib.request.urlopen(
                     f"http://{address}:18080/api/v1/applications"
                 ).read()
             )
+
+            apps = [app for app in raw_apps if app["id"] == spark_id]
         except Exception:
             apps = []
 
@@ -230,9 +251,12 @@ async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
 
 
 @pytest.mark.abort_on_fail
-async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, cos):
+async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, cos, tmp_folder):
     if not cos:
         pytest.skip("Not possible to test without cos")
+
+    driver_pod = Pod.load(tmp_folder / "spark-job-driver.json")
+
     show_status_cmd = ["status"]
 
     _, stdout, _ = await ops_test.juju(*show_status_cmd)
@@ -251,18 +275,13 @@ async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, c
         )
 
         logger.info(f"query: {query}")
-        spark_id = query["data"]["result"][0]["metric"]["exported_job"]
-        logger.info(f"Spark id: {spark_id}")
+        spark_ids = [
+            result["metric"]["exported_job"]
+            for result in query["data"]["result"]
+        ]
+        logger.info(f"Spark ids: {spark_ids}")
 
-        driver_pods = get_spark_drivers(
-            registry.kube_interface.client, service_account.namespace
-        )
-        assert len(driver_pods) == 1
-
-        logger.info(f"metadata: {driver_pods[0].metadata}")
-        spark_app_selector = driver_pods[0].labels["spark-app-selector"]
-        logger.info(f"Spark-app-selector: {spark_app_selector}")
-        assert spark_id == spark_app_selector
+        assert driver_pod.labels["spark-app-selector"] in spark_ids
 
 
 @pytest.mark.abort_on_fail
@@ -348,7 +367,7 @@ async def test_history_server_metrics_in_cos(ops_test: OpsTest, cos):
             # check if startup messages are there
             c = 0
             for timestamp, message in logs.items():
-                if "INFO HistoryServer" in message:
+                if "INFO FsHistoryProvider" in message:
                     c = c + 1
             logger.info(f"Number of line found: {c}")
             assert c > 0

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -44,7 +44,7 @@ LOKI = "loki"
 
 @pytest.fixture(scope="module")
 def container_name():
-    return f"spark-container-{uuid.uuid4()}"
+    return f"spark-container"
 
 
 @pytest.fixture

--- a/python/tests/integration/test_spark_job_azure.py
+++ b/python/tests/integration/test_spark_job_azure.py
@@ -69,7 +69,6 @@ async def test_deploy_bundle(ops_test: OpsTest, spark_bundle_with_azure_storage)
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_active_status(ops_test):
     """Test whether the bundle has deployed successfully."""
     for app_name in ops_test.model.applications:
@@ -82,7 +81,6 @@ def spark_properties(small_profile_properties, image_properties):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_run_job(
     ops_test: OpsTest, registry, service_account, pod, container, spark_properties
 ):
@@ -126,7 +124,6 @@ async def test_run_job(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_logs_are_persisted(
     ops_test: OpsTest, registry, service_account, container
 ):
@@ -161,7 +158,6 @@ async def test_job_logs_are_persisted(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_in_history_server(
     ops_test: OpsTest,
 ):
@@ -198,7 +194,6 @@ async def test_job_in_history_server(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")
@@ -235,7 +230,6 @@ async def test_job_in_prometheus_pushgateway(ops_test: OpsTest, cos):
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")
@@ -272,7 +266,6 @@ async def test_job_in_prometheus(ops_test: OpsTest, registry, service_account, c
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_spark_logforwaring_to_loki(
     ops_test: OpsTest, registry, service_account, cos
 ):
@@ -289,7 +282,6 @@ async def test_spark_logforwaring_to_loki(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.asyncio
 async def test_history_server_metrics_in_cos(ops_test: OpsTest, cos):
     if not cos:
         pytest.skip("Not possible to test without cos")

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -24,6 +24,7 @@ set_env =
     bundle: TESTFILE=test_bundle.py
     sparkjob: TESTFILE=test_spark_job.py
     kyuubi: TESTFILE=test_kyuubi.py
+    bundle-azure: TESTFILE=test_bundle_azure.py
     sparkjob-azure: TESTFILE=test_spark_job_azure.py
     kyuubi-azure: TESTFILE=test_kyuubi_azure.py
 
@@ -58,7 +59,7 @@ commands =
     poetry export -f requirements.txt -o requirements.txt
     poetry run pytest tests/unittest
 
-[testenv:integration-{basic,bundle,sparkjob,kyuubi,sparkjob-azure,kyuubi-azure}]
+[testenv:integration-{basic,bundle,sparkjob,kyuubi,bundle-azure,sparkjob-azure,kyuubi-azure}]
 description = Run integration tests
 setenv =
     IE_TEST=1


### PR DESCRIPTION
This PR introduce the possibility to run tests against existing deployments. In order to make this possible a few tweaks were required:

* Introducing the [`skip_if_deployed`](https://github.com/canonical/spark-k8s-bundle/pull/68/files#diff-bcb3b0a9ca0a773899b801df1f8b1210cfbf23e90937a5a71f8a2b8fd592879bR39) marker for the parts about deployments
* Remove the cleanup of resources such as buckets, containers and service accounts
* Tune logs specific checks that would fail on long-running deployments, as [here](https://github.com/canonical/spark-k8s-bundle/pull/68/files#diff-d9f67f8d2266059cbc219044cb7859b89eccf934319a30da8229808f864e20a9R202)
* add CI for making sure that tests are idempotent and can be run against an existing deployments, see [here](https://github.com/canonical/spark-k8s-bundle/pull/68/files#diff-99c529469d54c618fa9ecca522a479a3e821e220c31d874dcf5a04fcfe876bd3)

PS. I have disabled all the tests for the sake of having faster (and cheaper CI) until we get to a close to ready-to-be merged state