### PR TITLE
[DPE-7109] Bump Integration Hub and Kyuubi revision

### DIFF
--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -123,6 +123,10 @@ runs:
         AZURE_STORAGE_ACCOUNT: ${{ inputs.azure-storage-account }}
         AZURE_STORAGE_KEY: ${{ inputs.azure-storage-key }}
       run: |
-        sudo snap install --classic juju-crashdump
         juju list-models
         cd python && tox run -e ${{ inputs.tox-env }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --backend ${{ inputs.bundle-backend }} --cos-model ${{ inputs.cos-model }} --spark-version ${{ inputs.spark-version }} --storage-backend ${{ inputs.storage-backend }} --keep-models
+    - name: Collect logs if job failed
+      if: ${{ failure() }}
+      run: |
+        juju-crashdump
+        echo "Done"

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -132,3 +132,7 @@ runs:
       run: |
         juju-crashdump
         echo "Done"
+    - id: debug
+      name: Debug session
+      if: ${{ failure() }}   
+      uses: mxschmitt/action-tmate@v3

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -125,8 +125,10 @@ runs:
       run: |
         juju list-models
         cd python && tox run -e ${{ inputs.tox-env }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --backend ${{ inputs.bundle-backend }} --cos-model ${{ inputs.cos-model }} --spark-version ${{ inputs.spark-version }} --storage-backend ${{ inputs.storage-backend }} --keep-models
-    - name: Collect logs if job failed
-      if: ${{ failure() }}
+    - id: collect-logs
+      name: Collect logs if job failed
+      shell: bash
+      if: ${{ failure() }}   
       run: |
         juju-crashdump
         echo "Done"

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -132,7 +132,3 @@ runs:
       run: |
         juju-crashdump
         echo "Done"
-    - id: debug
-      name: Debug session
-      if: ${{ failure() }}   
-      uses: mxschmitt/action-tmate@v3

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -116,6 +116,8 @@ runs:
         sudo microk8s ctr images import --base-name $IMAGE image.tar
         docker rmi $IMAGE
         rm image.tar
+    - name: Setup tmate session
+      uses: canonical/action-tmate@main
     - id: tests-integration
       name: Run Integration Tests
       shell: bash
@@ -125,6 +127,3 @@ runs:
       run: |
         juju list-models
         cd python && tox run -e ${{ inputs.tox-env }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --backend ${{ inputs.bundle-backend }} --cos-model ${{ inputs.cos-model }} --spark-version ${{ inputs.spark-version }} --storage-backend ${{ inputs.storage-backend }} --keep-models
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: canonical/action-tmate@main

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -123,5 +123,6 @@ runs:
         AZURE_STORAGE_ACCOUNT: ${{ inputs.azure-storage-account }}
         AZURE_STORAGE_KEY: ${{ inputs.azure-storage-key }}
       run: |
+        sudo snap install --classic juju-crashdump
         juju list-models
         cd python && tox run -e ${{ inputs.tox-env }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --backend ${{ inputs.bundle-backend }} --cos-model ${{ inputs.cos-model }} --spark-version ${{ inputs.spark-version }} --storage-backend ${{ inputs.storage-backend }} --keep-models

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -116,8 +116,8 @@ runs:
         sudo microk8s ctr images import --base-name $IMAGE image.tar
         docker rmi $IMAGE
         rm image.tar
-    - name: Setup tmate session
-      uses: canonical/action-tmate@main
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
     - id: tests-integration
       name: Run Integration Tests
       shell: bash

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: true
   spark-version:
     description: "The version of Spark to run the tests on"
-    default: 3.4.2
+    default: 3.4.4
     required: false
     type: string
   bundle-backend:
@@ -125,3 +125,6 @@ runs:
       run: |
         juju list-models
         cd python && tox run -e ${{ inputs.tox-env }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --backend ${{ inputs.bundle-backend }} --cos-model ${{ inputs.cos-model }} --spark-version ${{ inputs.spark-version }} --storage-backend ${{ inputs.storage-backend }} --keep-models
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: canonical/action-tmate@main

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -109,15 +109,13 @@ runs:
       shell: bash
       run: |
         # Download image for avoiding time out
-        IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:3c49dfe71387bd702a30844c80c9a17a8bc8ecb99ebdee37eab4b05e44ac683f"
+        IMAGE="ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5"
 
         docker pull $IMAGE
         docker save $IMAGE -o image.tar
         sudo microk8s ctr images import --base-name $IMAGE image.tar
         docker rmi $IMAGE
         rm image.tar
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
     - id: tests-integration
       name: Run Integration Tests
       shell: bash

--- a/.github/workflows/ci-tests-full.yaml
+++ b/.github/workflows/ci-tests-full.yaml
@@ -25,7 +25,7 @@ jobs:
           - integration-bundle
           - integration-kyuubi
         bundle-backend: ["yaml", "terraform"]
-        spark-version: ["3.4.2", "3.5.1"]
+        spark-version: ["3.4.4", "3.5.4"]
         storage-backend: ["s3", "azure"]
         cos-model: ["", "cos"]
         juju:
@@ -43,12 +43,12 @@ jobs:
             cos-model:
         include:
           - tox-env: integration-basic
-            spark-version: 3.4.2
+            spark-version: 3.4.4
             juju:
               - snap_channel: "3.6/stable"
                 agent: "3.6.0"
           - tox-env: integration-basic
-            spark-version: 3.5.1
+            spark-version: 3.5.4
             juju:
               - snap_channel: "3.6/stable"
                 agent: "3.6.0"

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -18,30 +18,30 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        # tox-env:
-        #   - integration-sparkjob
-        #   - integration-bundle
-        #   - integration-kyuubi
-        # bundle-backend: ["terraform"]
-        # spark-version: ["3.4.4"]
-        # storage-backend: ["s3", "azure"]
-        # cos-model: ["cos"]
-        # juju:
-        #   - snap_channel: "3.5/stable"
-        #     agent: "3.5.6"
-        #   - snap_channel: "3.6/stable"
-        #     agent: "3.6.0"
+        tox-env:
+          - integration-sparkjob
+          - integration-bundle
+          - integration-kyuubi
+        bundle-backend: ["terraform"]
+        spark-version: ["3.4.4"]
+        storage-backend: ["s3", "azure"]
+        cos-model: ["cos"]
+        juju:
+          - snap_channel: "3.5/stable"
+            agent: "3.5.6"
+          - snap_channel: "3.6/stable"
+            agent: "3.6.0"
         include:
-        #   - tox-env: integration-basic
-        #     spark-version: 3.4.4
-        #     juju:
-        #       - snap_channel: "3.6/stable"
-        #         agent: "3.6.0"
-        #   - tox-env: integration-basic
-        #     spark-version: 3.5.4
-        #     juju:
-        #       - snap_channel: "3.6/stable"
-        #         agent: "3.6.0"
+          - tox-env: integration-basic
+            spark-version: 3.4.4
+            juju:
+              - snap_channel: "3.6/stable"
+                agent: "3.6.0"
+          - tox-env: integration-basic
+            spark-version: 3.5.4
+            juju:
+              - snap_channel: "3.6/stable"
+                agent: "3.6.0"
           - tox-env: integration-bundle
             bundle-backend: yaml
             spark-version: 3.4.4

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run integration test
         uses: ./.github/actions/run-test
-        timeout-minutes: 15
+        timeout-minutes: 40
         with:
           tox-env: ${{ matrix.tox-env }}
           bundle-backend: ${{ matrix.bundle-backend }}

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -23,7 +23,7 @@ jobs:
           - integration-bundle
           - integration-kyuubi
         bundle-backend: ["terraform"]
-        spark-version: ["3.4.2"]
+        spark-version: ["3.4.4"]
         storage-backend: ["s3", "azure"]
         cos-model: ["cos"]
         juju:
@@ -33,18 +33,18 @@ jobs:
             agent: "3.6.0"
         include:
           - tox-env: integration-basic
-            spark-version: 3.4.2
+            spark-version: 3.4.4
             juju:
               - snap_channel: "3.6/stable"
                 agent: "3.6.0"
           - tox-env: integration-basic
-            spark-version: 3.5.1
+            spark-version: 3.5.4
             juju:
               - snap_channel: "3.6/stable"
                 agent: "3.6.0"
           - tox-env: integration-bundle
             bundle-backend: yaml
-            spark-version: 3.4.2
+            spark-version: 3.4.4
             juju:
               - snap_channel: "3.6/stable"
                 agent: "3.6.0"

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -18,30 +18,30 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        tox-env:
-          - integration-sparkjob
-          - integration-bundle
-          - integration-kyuubi
-        bundle-backend: ["terraform"]
-        spark-version: ["3.4.4"]
-        storage-backend: ["s3", "azure"]
-        cos-model: ["cos"]
-        juju:
-          - snap_channel: "3.5/stable"
-            agent: "3.5.6"
-          - snap_channel: "3.6/stable"
-            agent: "3.6.0"
+        # tox-env:
+        #   - integration-sparkjob
+        #   - integration-bundle
+        #   - integration-kyuubi
+        # bundle-backend: ["terraform"]
+        # spark-version: ["3.4.4"]
+        # storage-backend: ["s3", "azure"]
+        # cos-model: ["cos"]
+        # juju:
+        #   - snap_channel: "3.5/stable"
+        #     agent: "3.5.6"
+        #   - snap_channel: "3.6/stable"
+        #     agent: "3.6.0"
         include:
-          - tox-env: integration-basic
-            spark-version: 3.4.4
-            juju:
-              - snap_channel: "3.6/stable"
-                agent: "3.6.0"
-          - tox-env: integration-basic
-            spark-version: 3.5.4
-            juju:
-              - snap_channel: "3.6/stable"
-                agent: "3.6.0"
+        #   - tox-env: integration-basic
+        #     spark-version: 3.4.4
+        #     juju:
+        #       - snap_channel: "3.6/stable"
+        #         agent: "3.6.0"
+        #   - tox-env: integration-basic
+        #     spark-version: 3.5.4
+        #     juju:
+        #       - snap_channel: "3.6/stable"
+        #         agent: "3.6.0"
           - tox-env: integration-bundle
             bundle-backend: yaml
             spark-version: 3.4.4

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -72,7 +72,3 @@ jobs:
         run: |
           juju-crashdump
           echo "Done"
-      - id: debug
-        name: Debug session
-        if: ${{ failure() }}   
-        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -67,3 +67,12 @@ jobs:
           juju-agent-version: ${{ matrix.juju.agent || '3.6.0' }}
           azure-storage-account: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
           azure-storage-key: ${{ secrets.AZURE_STORAGE_KEY }}
+      - name: Collect logs if job failed
+        if: ${{ failure() }}   
+        run: |
+          juju-crashdump
+          echo "Done"
+      - id: debug
+        name: Debug session
+        if: ${{ failure() }}   
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run integration test
         uses: ./.github/actions/run-test
-        timeout-minutes: 40
+        timeout-minutes: 15
         with:
           tox-env: ${{ matrix.tox-env }}
           bundle-backend: ${{ matrix.bundle-backend }}

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - --spark-version "3.4.2"
+          - --spark-version "3.4.4"
         backend:
           - --backend terraform
         storage-backend:

--- a/python/spark_test/fixtures/pod.py
+++ b/python/spark_test/fixtures/pod.py
@@ -25,7 +25,7 @@ def admin_pod_name():
 @pytest.fixture(scope="module")
 def spark_version():
     """Spark version."""
-    return "3.4.2"
+    return "3.4.4"
 
 
 @pytest.fixture(scope="module")

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -98,8 +98,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--spark-version",
         nargs="?",
-        const="3.4.2",
-        default="3.4.2",
+        const="3.4.4",
+        default="3.4.4",
         type=str,
         help="Which Spark version to use for bundle testing.",
     )
@@ -136,7 +136,7 @@ def backend(request) -> None | str:
 @pytest.fixture(scope="module")
 def spark_version(request) -> str:
     """The backend which is to be used to deploy the bundle."""
-    return request.config.getoption("--spark-version") or "3.4.2"
+    return request.config.getoption("--spark-version") or "3.4.4"
 
 
 @pytest.fixture(scope="module")

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 51       |
+| spark         | kyuubi-k8s                   | latest/edge   | 52       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -108,8 +108,8 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-pushgateway-k8s   | latest/stable | 16       |
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
-| spark         | spark-integration-hub-k8s    | latest/edge   | 46       |
-| spark         | kyuubi-k8s                   | latest/edge   | 45       |
+| spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
+| spark         | kyuubi-k8s                   | latest/edge   | 50       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -102,11 +102,11 @@ This means that using this structure, a new optional module just takes care of d
 
 | Module        | Charm                        | Channel       | revision |
 | ------------- | ---------------------------- | ------------- | -------- |
-| azure         | azure-storage-integrator     | latest/edge   | 12        |
+| azure         | azure-storage-integrator     | latest/edge   | 12       |
 | observability | grafana-agent-k8s            | latest/stable | 104      |
 | observability | cos-configuration-k8s        | latest/stable | 67       |
 | observability | prometheus-pushgateway-k8s   | latest/stable | 16       |
-| observability | prometheus-scrape-config-k8s | latest/stable | 56       |
+| observability | prometheus-scrape-config-k8s | latest/stable | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
 | spark         | kyuubi-k8s                   | latest/edge   | 60       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 52       |
+| spark         | kyuubi-k8s                   | latest/edge   | 60       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 50       |
+| spark         | kyuubi-k8s                   | latest/edge   | 51       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.4/terraform/modules/observability/applications.tf
+++ b/releases/3.4/terraform/modules/observability/applications.tf
@@ -51,7 +51,7 @@ resource "juju_application" "scrape_config" {
   charm {
     name     = "prometheus-scrape-config-k8s"
     channel  = "latest/stable"
-    revision = 51
+    revision = 64
   }
   config = {
     scrape_interval = "10s"

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 53
+    revision = 54
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 56
+    revision = 57
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 50
+    revision = 51
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 58
+    revision = 60
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,11 +27,11 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 45
+    revision = 50
   }
 
   resources = {
-    kyuubi-image = "ghcr.io/canonical/charmed-spark-kyuubi@sha256:3c49dfe71387bd702a30844c80c9a17a8bc8ecb99ebdee37eab4b05e44ac683f" # 3.4.2
+    kyuubi-image = "ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5" # 3.4.4-1.10.1-22.04_edge 2025-05-06
   }
 
   config = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 54
+    revision = 56
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 57
+    revision = 58
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -93,7 +93,7 @@ resource "juju_application" "hub" {
   charm {
     name     = "spark-integration-hub-k8s"
     channel  = "latest/edge"
-    revision = 48
+    revision = 49
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 52
+    revision = 53
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -93,7 +93,7 @@ resource "juju_application" "hub" {
   charm {
     name     = "spark-integration-hub-k8s"
     channel  = "latest/edge"
-    revision = 46
+    revision = 48
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 55
+    revision = 54
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 54
+    revision = 55
   }
 
   resources = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 51
+    revision = 52
   }
 
   resources = {

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 58
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 58
+    revision: 60
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 52
+    revision: 53
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 50
+    revision: 51
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 53
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -67,7 +67,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 46
+    revision: 49
     resources:
       integration-hub-image: 3
     scale: 1

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,9 +6,9 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 39
+    revision: 50
     resources:
-      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:9268d19a6eef91914e874734b320fab64908faf0f7adb8856be809bc60ecd1d0 # 3.4.2
+      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
     options:
       namespace: {{ namespace }}
@@ -69,7 +69,7 @@ applications:
     channel: latest/edge
     revision: 49
     resources:
-      integration-hub-image: 3
+      integration-hub-image: 5
     scale: 1
     constraints: arch=amd64
     trust: true

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 51
+    revision: 52
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 56
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 58
+    revision: 60
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 52
+    revision: 53
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 50
+    revision: 51
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 53
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 55
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 57
+    revision: 58
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -67,7 +67,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 46
+    revision: 49
     resources:
       integration-hub-image: 3
     scale: 1

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 55
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 56
+    revision: 57
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 51
+    revision: 52
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,9 +6,9 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 45
+    revision: 50
     resources:
-      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:3c49dfe71387bd702a30844c80c9a17a8bc8ecb99ebdee37eab4b05e44ac683f # 3.4.2
+      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
     options:
       namespace: {{ namespace }}
@@ -69,7 +69,7 @@ applications:
     channel: latest/edge
     revision: 49
     resources:
-      integration-hub-image: 3
+      integration-hub-image: 5
     scale: 1
     constraints: arch=amd64
     trust: true

--- a/releases/3.4/yaml/docs/explanation/e-configuration.md
+++ b/releases/3.4/yaml/docs/explanation/e-configuration.md
@@ -1,6 +1,6 @@
 ## Apache Spark Configuration Management
 
-Apache Spark comes with a wide range of [configuration properties](https://spark.apache.org/docs/3.4.4/configuration.html#available-properties) that can be fed into Apache Spark using a single property file, e.g. `spark.properties`, or by passing configuration values on the command line, as an argument to `spark-submit`, `pyspark` and `spark-shell`.
+Apache Spark comes with a wide range of [configuration properties](https://spark.apache.org/docs/3.4.2/configuration.html#available-properties) that can be fed into Apache Spark using a single property file, e.g. `spark.properties`, or by passing configuration values on the command line, as an argument to `spark-submit`, `pyspark` and `spark-shell`.
 
 Charmed Apache Spark improves on this capability by enabling a set of hierarchical layers of configurations, that are merged and overridden based on a precedence rule. 
 

--- a/releases/3.4/yaml/docs/explanation/e-configuration.md
+++ b/releases/3.4/yaml/docs/explanation/e-configuration.md
@@ -1,6 +1,6 @@
 ## Apache Spark Configuration Management
 
-Apache Spark comes with a wide range of [configuration properties](https://spark.apache.org/docs/3.4.2/configuration.html#available-properties) that can be fed into Apache Spark using a single property file, e.g. `spark.properties`, or by passing configuration values on the command line, as an argument to `spark-submit`, `pyspark` and `spark-shell`.
+Apache Spark comes with a wide range of [configuration properties](https://spark.apache.org/docs/3.4.4/configuration.html#available-properties) that can be fed into Apache Spark using a single property file, e.g. `spark.properties`, or by passing configuration values on the command line, as an argument to `spark-submit`, `pyspark` and `spark-shell`.
 
 Charmed Apache Spark improves on this capability by enabling a set of hierarchical layers of configurations, that are merged and overridden based on a precedence rule. 
 

--- a/releases/3.4/yaml/overlays/cos-integration.yaml.j2
+++ b/releases/3.4/yaml/overlays/cos-integration.yaml.j2
@@ -52,7 +52,7 @@ applications:
   scrape-config:
     charm: prometheus-scrape-config-k8s
     channel: latest/stable
-    revision: 51
+    revision: 64
     base: ubuntu@20.04/stable
     scale: 1
     options:

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 51       |
+| spark         | kyuubi-k8s                   | latest/edge   | 52       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -108,8 +108,8 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-pushgateway-k8s   | latest/stable | 16       |
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
-| spark         | spark-integration-hub-k8s    | latest/edge   | 46       |
-| spark         | kyuubi-k8s                   | latest/edge   | 45       |
+| spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
+| spark         | kyuubi-k8s                   | latest/edge   | 50       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -102,11 +102,11 @@ This means that using this structure, a new optional module just takes care of d
 
 | Module        | Charm                        | Channel       | revision |
 | ------------- | ---------------------------- | ------------- | -------- |
-| azure         | azure-storage-integrator     | latest/edge   | 12        |
+| azure         | azure-storage-integrator     | latest/edge   | 12       |
 | observability | grafana-agent-k8s            | latest/stable | 104      |
 | observability | cos-configuration-k8s        | latest/stable | 67       |
 | observability | prometheus-pushgateway-k8s   | latest/stable | 16       |
-| observability | prometheus-scrape-config-k8s | latest/stable | 56       |
+| observability | prometheus-scrape-config-k8s | latest/stable | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
 | spark         | kyuubi-k8s                   | latest/edge   | 60       |

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 52       |
+| spark         | kyuubi-k8s                   | latest/edge   | 60       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | latest/stable | 56       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 50       |
+| spark         | kyuubi-k8s                   | latest/edge   | 51       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.5/terraform/modules/observability/applications.tf
+++ b/releases/3.5/terraform/modules/observability/applications.tf
@@ -50,7 +50,7 @@ resource "juju_application" "scrape_config" {
   charm {
     name     = "prometheus-scrape-config-k8s"
     channel  = "latest/stable"
-    revision = 51
+    revision = 64
   }
   config = {
     scrape_interval = "10s"

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 53
+    revision = 54
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 56
+    revision = 57
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 50
+    revision = 51
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 58
+    revision = 60
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,11 +27,11 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 45
+    revision = 50
   }
 
   resources = {
-    kyuubi-image = "ghcr.io/canonical/charmed-spark-kyuubi@sha256:3c49dfe71387bd702a30844c80c9a17a8bc8ecb99ebdee37eab4b05e44ac683f" # 3.4.2
+    kyuubi-image = "ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5" # 3.4.4-1.10.1-22.04_edge 2025-05-06
   }
 
   config = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 54
+    revision = 56
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 57
+    revision = 58
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -93,7 +93,7 @@ resource "juju_application" "hub" {
   charm {
     name     = "spark-integration-hub-k8s"
     channel  = "latest/edge"
-    revision = 48
+    revision = 49
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 52
+    revision = 53
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -93,7 +93,7 @@ resource "juju_application" "hub" {
   charm {
     name     = "spark-integration-hub-k8s"
     channel  = "latest/edge"
-    revision = 46
+    revision = 48
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 55
+    revision = 54
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 54
+    revision = 55
   }
 
   resources = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -27,7 +27,7 @@ resource "juju_application" "kyuubi" {
   charm {
     name     = "kyuubi-k8s"
     channel  = "latest/edge"
-    revision = 51
+    revision = 52
   }
 
   resources = {

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 58
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 58
+    revision: 60
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 52
+    revision: 53
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 50
+    revision: 51
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 53
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -67,7 +67,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 46
+    revision: 49
     resources:
       integration-hub-image: 3
     scale: 1

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,9 +6,9 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 39
+    revision: 50
     resources:
-      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:931efb21837866102a3b89239212107eb517fd8ba573aa62623048f29d5c337c # 3.5.1
+      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
     options:
       namespace: {{ namespace }}
@@ -69,7 +69,7 @@ applications:
     channel: latest/edge
     revision: 49
     resources:
-      integration-hub-image: 3
+      integration-hub-image: 5
     scale: 1
     constraints: arch=amd64
     trust: true

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 51
+    revision: 52
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 56
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 58
+    revision: 60
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 52
+    revision: 53
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 50
+    revision: 51
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 53
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 54
+    revision: 55
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 57
+    revision: 58
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -67,7 +67,7 @@ applications:
   integration-hub:
     charm: spark-integration-hub-k8s
     channel: latest/edge
-    revision: 46
+    revision: 49
     resources:
       integration-hub-image: 3
     scale: 1

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 55
+    revision: 54
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 56
+    revision: 57
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 51
+    revision: 52
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,9 +6,9 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 45
+    revision: 50
     resources:
-      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:3c49dfe71387bd702a30844c80c9a17a8bc8ecb99ebdee37eab4b05e44ac683f # 3.4.2
+      kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
     options:
       namespace: {{ namespace }}
@@ -69,7 +69,7 @@ applications:
     channel: latest/edge
     revision: 49
     resources:
-      integration-hub-image: 3
+      integration-hub-image: 5
     scale: 1
     constraints: arch=amd64
     trust: true

--- a/releases/3.5/yaml/overlays/cos-integration.yaml.j2
+++ b/releases/3.5/yaml/overlays/cos-integration.yaml.j2
@@ -52,7 +52,7 @@ applications:
   scrape-config:
     charm: prometheus-scrape-config-k8s
     channel: latest/stable
-    revision: 51
+    revision: 64
     base: ubuntu@20.04/stable
     scale: 1
     options:


### PR DESCRIPTION
* Bump Integration Hub revision to rev49, to include fixes performed in https://github.com/canonical/spark-integration-hub-k8s-operator/pull/66
* Bump Kyuubi to rev60 to include fixes performed in https://github.com/canonical/kyuubi-k8s-operator/pull/80
* Update the image versions for Kyuubi to 3.4.4