### PR TITLE
[DPE-7529] Replace get-jdbc-endpoint with data-integrator

### DIFF
--- a/python/tests/integration/bench/conftest.py
+++ b/python/tests/integration/bench/conftest.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 
@@ -73,3 +75,12 @@ def kyuubi(request):
 @pytest.fixture(scope="module")
 def hub(request):
     return request.config.getoption("--hub-app")
+
+
+@pytest.fixture(scope="session")
+def spark_client() -> str:
+    """Check that spark-client is in path."""
+    if (spark_client_path := shutil.which("spark-client")) is None:
+        raise FileNotFoundError("Could not find 'spark-client' in PATH.")
+
+    return spark_client_path

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -64,9 +64,11 @@ def set_s3_credentials(
     assert task.return_code == 0
 
 
-def get_kyuubi_credentials(juju: jubilant.Juju) -> KyuubiCredentials:
+def get_kyuubi_credentials(
+    juju: jubilant.Juju, data_integrator_unit: str = "data-integrator/0"
+) -> KyuubiCredentials:
     """Use the charm action to start a password rotation."""
-    task = juju.run("data-integrator/0", "get-credentials")
+    task = juju.run(data_integrator_unit, "get-credentials")
     assert task.return_code == 0
     kyuubi_info = task.results["kyuubi"]
     endpoint = kyuubi_info["uris"]

--- a/python/tests/integration/helpers.py
+++ b/python/tests/integration/helpers.py
@@ -64,26 +64,12 @@ def set_s3_credentials(
     assert task.return_code == 0
 
 
-def get_leader_unit(juju: jubilant.Juju, app: str) -> str:
-    status = juju.status()
-    leader_unit = None
-    for name, unit in status.apps[app].units.items():
-        if unit.leader:
-            leader_unit = name
-    assert leader_unit
-    return leader_unit
-
-
-def get_kyuubi_credentials(
-    juju: jubilant.Juju, application_name="kyuubi"
-) -> KyuubiCredentials:
+def get_kyuubi_credentials(juju: jubilant.Juju) -> KyuubiCredentials:
     """Use the charm action to start a password rotation."""
-    leader_unit = get_leader_unit(juju, application_name)
-    task = juju.run(leader_unit, "get-password")
+    task = juju.run("data-integrator/0", "get-credentials")
     assert task.return_code == 0
-    results = task.results
-
-    endpoint = fetch_jdbc_endpoint(juju)
+    kyuubi_info = task.results["kyuubi"]
+    endpoint = kyuubi_info["uris"]
     logger.info(endpoint)
 
     if (
@@ -100,22 +86,11 @@ def get_kyuubi_credentials(
                 address = unit.address
         assert address
 
-    return {"username": "admin", "password": results["password"], "host": address}
-
-
-def fetch_jdbc_endpoint(juju: jubilant.Juju) -> str:
-    """Return the JDBC endpoint for clients to connect to Kyuubi server."""
-    logger.info("Running action 'get-jdbc-endpoint' on kyuubi-k8s unit...")
-    leader_unit = get_leader_unit(juju, "kyuubi")
-    task = juju.run(leader_unit, "get-jdbc-endpoint")
-    assert task.return_code == 0
-    logger.info(f"result: {task.results}")
-
-    jdbc_endpoint = task.results["endpoint"]
-    assert jdbc_endpoint
-    logger.info(f"JDBC endpoint: {jdbc_endpoint}")
-
-    return jdbc_endpoint
+    return {
+        "username": kyuubi_info["username"],
+        "password": kyuubi_info["password"],
+        "host": address,
+    }
 
 
 def get_zookeeper_quorum(juju: jubilant.Juju, zookeeper_name: str) -> str:

--- a/python/tests/integration/test_kyuubi.py
+++ b/python/tests/integration/test_kyuubi.py
@@ -50,7 +50,7 @@ def test_authentication_is_enforced(juju: jubilant.Juju) -> None:
     """Test that the authentication has been enabled in the bundle by default
     and thus Kyuubi accept connections with invalid credentials.
     """
-    credentials = get_kyuubi_credentials(juju, "kyuubi")
+    credentials = get_kyuubi_credentials(juju)
     credentials["password"] = "something-random"
 
     with pytest.raises(Exception) as e:
@@ -63,7 +63,7 @@ def test_authentication_is_enforced(juju: jubilant.Juju) -> None:
 def test_jdbc_endpoint(juju: jubilant.Juju) -> None:
     """Test that JDBC connection in Kyuubi works out of the box in bundle."""
 
-    credentials = get_kyuubi_credentials(juju, "kyuubi")
+    credentials = get_kyuubi_credentials(juju)
 
     logger.info("Get certificate from self-signed-certificates operator")
     status = juju.status()
@@ -201,7 +201,7 @@ def test_kyuubi_metrics_in_cos(juju: jubilant.Juju, cos) -> None:
 
 
 def test_drop_table_if_exists(juju: jubilant.Juju) -> None:
-    credentials = get_kyuubi_credentials(juju, "kyuubi")
+    credentials = get_kyuubi_credentials(juju)
     client = KyuubiClient(**credentials, use_ssl=True)
 
     db_name, table_name = "spark_test", "my_table"

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 85       |
+| spark         | kyuubi-k8s                   | latest/edge   | 87       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/stable      | 75       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 72       |
+| spark         | kyuubi-k8s                   | latest/edge   | 85       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/stable      | 75       |

--- a/releases/3.4/terraform/README.md
+++ b/releases/3.4/terraform/README.md
@@ -100,20 +100,21 @@ This means that using this structure, a new optional module just takes care of d
 
 ## Versions
 
-| Module        | Charm                        | Channel     | revision |
-| ------------- | ---------------------------- | ----------- | -------- |
-| azure         | azure-storage-integrator     | latest/edge | 12       |
-| observability | grafana-agent-k8s            | 1/stable    | 104      |
-| observability | cos-configuration-k8s        | 1/stable    | 67       |
-| observability | prometheus-pushgateway-k8s   | 1/stable    | 16       |
-| observability | prometheus-scrape-config-k8s | 1/stable    | 64       |
-| spark         | spark-history-server-k8s     | 3.4/edge    | 40       |
-| spark         | spark-integration-hub-k8s    | latest/edge | 49       |
-| spark         | kyuubi-k8s                   | latest/edge | 72       |
-| spark         | postgresql-k8s               | 14/stable   | 281      |
-| spark         | postgresql-k8s               | 14/stable   | 281      |
-| spark         | zookeeper-k8s                | 3/edge      | 75       |
-| s3            | s3-integrator                | 1/stable    | 145      |
+| Module        | Charm                        | Channel       | revision |
+| ------------- | ---------------------------- | ------------- | -------- |
+| azure         | azure-storage-integrator     | latest/edge   | 12       |
+| observability | grafana-agent-k8s            | 1/stable      | 104      |
+| observability | cos-configuration-k8s        | 1/stable      | 67       |
+| observability | prometheus-pushgateway-k8s   | 1/stable      | 16       |
+| observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
+| spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
+| spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
+| spark         | kyuubi-k8s                   | latest/edge   | 72       |
+| spark         | postgresql-k8s               | 14/stable     | 281      |
+| spark         | postgresql-k8s               | 14/stable     | 281      |
+| spark         | zookeeper-k8s                | 3/stable      | 75       |
+| spark         | data-integrator              | latest/stable | 161      |
+| s3            | s3-integrator                | 1/stable      | 145      |
 
 ### Updating the version table
 

--- a/releases/3.4/terraform/main.tf
+++ b/releases/3.4/terraform/main.tf
@@ -52,6 +52,7 @@ module "spark" {
   metastore_image          = var.metastore_image != null ? var.metastore_image : local.images.metastore
   zookeeper_revision       = var.zookeeper_revision != null ? var.zookeeper_revision : local.revisions.zookeeper
   zookeeper_image          = var.zookeeper_image != null ? var.zookeeper_image : local.images.zookeeper
+  data_integrator_revision = var.data_integrator_revision != null ? var.data_integrator_revision : local.revisions.data_integrator
 }
 
 module "azure_storage" {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -121,6 +121,10 @@ resource "juju_application" "data_integrator" {
     revision = 161
   }
 
+  config = {
+    database-name = "integrator"
+  }
+
   units       = 1
   constraints = "arch=amd64"
 }

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -110,3 +110,17 @@ resource "juju_application" "zookeeper" {
   units       = var.zookeeper_units
   constraints = "arch=amd64"
 }
+
+resource "juju_application" "data-integrator" {
+  name  = "data-integrator"
+  model = data.juju_model.spark.name
+
+  charm {
+    name     = "data-integrator"
+    channel  = "latest/stable"
+    revision = 161
+  }
+
+  units       = 1
+  constraints = "arch-amd64"
+}

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -118,7 +118,7 @@ resource "juju_application" "data_integrator" {
   charm {
     name     = "data-integrator"
     channel  = "latest/stable"
-    revision = 161
+    revision = var.data_integrator_revision
   }
 
   config = {

--- a/releases/3.4/terraform/modules/spark/applications.tf
+++ b/releases/3.4/terraform/modules/spark/applications.tf
@@ -111,7 +111,7 @@ resource "juju_application" "zookeeper" {
   constraints = "arch=amd64"
 }
 
-resource "juju_application" "data-integrator" {
+resource "juju_application" "data_integrator" {
   name  = "data-integrator"
   model = data.juju_model.spark.name
 
@@ -122,5 +122,5 @@ resource "juju_application" "data-integrator" {
   }
 
   units       = 1
-  constraints = "arch-amd64"
+  constraints = "arch=amd64"
 }

--- a/releases/3.4/terraform/modules/spark/integrations.tf
+++ b/releases/3.4/terraform/modules/spark/integrations.tf
@@ -70,3 +70,17 @@ resource "juju_integration" "kyuubi_tls" {
     endpoint = var.tls_certificates_endpoint
   }
 }
+
+resource "juju_integration" "kyuubi_data_integrator" {
+  model = data.juju_model.spark.name
+
+  application {
+    name     = juju_application.kyuubi.name
+    endpoint = "jdbc"
+  }
+
+  application {
+    name     = juju_application.data_integrator.name
+    endpoint = "kyuubi"
+  }
+}

--- a/releases/3.4/terraform/modules/spark/variables.tf
+++ b/releases/3.4/terraform/modules/spark/variables.tf
@@ -106,3 +106,9 @@ variable "zookeeper_image" {
   type        = map(string)
   nullable    = false
 }
+
+variable "data_integrator_revision" {
+  description = "Charm revision for data-integrator"
+  type        = number
+  nullable    = false
+}

--- a/releases/3.4/terraform/variables.tf
+++ b/releases/3.4/terraform/variables.tf
@@ -185,6 +185,12 @@ variable "zookeeper_image" {
   default     = null
 }
 
+variable "data_integrator_revision" {
+  description = "Charm revision for data-integrator"
+  type        = number
+  default     = null
+}
+
 variable "s3_revision" {
   description = "Charm revision for s3-integrator"
   type        = number

--- a/releases/3.4/terraform/versions.tf
+++ b/releases/3.4/terraform/versions.tf
@@ -14,10 +14,11 @@ locals {
   revisions = {
     history_server    = 40
     integration_hub   = 49
-    kyuubi            = 72
+    kyuubi            = 87
     kyuubi_users      = 281
     metastore         = 281
     zookeeper         = 75
+    data_integrator   = 161
     s3                = 77
     azure_storage     = 12
     grafana_agent     = 104

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 73
+    revision: 85
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 72
+    revision: 73
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
@@ -73,6 +73,12 @@ applications:
     scale: 1
     constraints: arch=amd64
     trust: true
+  data-integrator:
+    charm: data-integrator
+    channel: latest/stable
+    revision: 161
+    scale: 1
+    constraints: arch=amd64
 relations:
 - - integration-hub:azure-storage-credentials
   - azure-storage:azure-storage-credentials
@@ -86,3 +92,5 @@ relations:
   - integration-hub:spark-service-account
 - - kyuubi:zookeeper
   - zookeeper:zookeeper
+- - kyuubi:jdbc
+  - data-integrator:kyuubi

--- a/releases/3.4/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.4/yaml/bundle-azure-storage.yaml.j2
@@ -79,6 +79,8 @@ applications:
     revision: 161
     scale: 1
     constraints: arch=amd64
+    options:
+      database-name: integrator
 relations:
 - - integration-hub:azure-storage-credentials
   - azure-storage:azure-storage-credentials

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -86,6 +86,8 @@ applications:
     revision: 161
     scale: 1
     constraints: arch=amd64
+    options:
+      database-name: integrator
 relations:
 - - integration-hub:s3-credentials
   - s3:s3-credentials

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 73
+    revision: 85
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.4/yaml/bundle.yaml.j2
+++ b/releases/3.4/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 72
+    revision: 73
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
@@ -80,6 +80,12 @@ applications:
     scale: 1
     constraints: arch=amd64
     trust: true
+  data-integrator:
+    charm: data-integrator
+    channel: latest/stable
+    revision: 161
+    scale: 1
+    constraints: arch=amd64
 relations:
 - - integration-hub:s3-credentials
   - s3:s3-credentials
@@ -95,3 +101,5 @@ relations:
   - zookeeper:zookeeper
 - - kyuubi:certificates
   - certificates:certificates
+- - kyuubi:jdbc
+  - data-integrator:kyuubi

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -100,20 +100,21 @@ This means that using this structure, a new optional module just takes care of d
 
 ## Versions
 
-| Module        | Charm                        | Channel     | revision |
-| ------------- | ---------------------------- | ----------- | -------- |
-| azure         | azure-storage-integrator     | latest/edge | 12       |
-| observability | grafana-agent-k8s            | 1/stable    | 104      |
-| observability | cos-configuration-k8s        | 1/stable    | 67       |
-| observability | prometheus-pushgateway-k8s   | 1/stable    | 16       |
-| observability | prometheus-scrape-config-k8s | 1/stable    | 64       |
-| spark         | spark-history-server-k8s     | 3.4/edge    | 40       |
-| spark         | spark-integration-hub-k8s    | latest/edge | 49       |
-| spark         | kyuubi-k8s                   | latest/edge | 72       |
-| spark         | postgresql-k8s               | 14/stable   | 281      |
-| spark         | postgresql-k8s               | 14/stable   | 281      |
-| spark         | zookeeper-k8s                | 3/edge      | 75       |
-| s3            | s3-integrator                | 1/stable    | 145      |
+| Module        | Charm                        | Channel       | revision |
+| ------------- | ---------------------------- | ------------- | -------- |
+| azure         | azure-storage-integrator     | latest/edge   | 12       |
+| observability | grafana-agent-k8s            | 1/stable      | 104      |
+| observability | cos-configuration-k8s        | 1/stable      | 67       |
+| observability | prometheus-pushgateway-k8s   | 1/stable      | 16       |
+| observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
+| spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
+| spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
+| spark         | kyuubi-k8s                   | latest/edge   | 72       |
+| spark         | postgresql-k8s               | 14/stable     | 281      |
+| spark         | postgresql-k8s               | 14/stable     | 281      |
+| spark         | zookeeper-k8s                | 3/edge        | 75       |
+| spark         | data-integrator              | latest/stable | 161      |
+| s3            | s3-integrator                | 1/stable      | 145      |
 
 ### Updating the version table
 

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -109,7 +109,7 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 72       |
+| spark         | kyuubi-k8s                   | latest/edge   | 85       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | zookeeper-k8s                | 3/edge        | 75       |

--- a/releases/3.5/terraform/README.md
+++ b/releases/3.5/terraform/README.md
@@ -109,10 +109,10 @@ This means that using this structure, a new optional module just takes care of d
 | observability | prometheus-scrape-config-k8s | 1/stable      | 64       |
 | spark         | spark-history-server-k8s     | 3.4/edge      | 40       |
 | spark         | spark-integration-hub-k8s    | latest/edge   | 49       |
-| spark         | kyuubi-k8s                   | latest/edge   | 85       |
+| spark         | kyuubi-k8s                   | latest/edge   | 87       |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
 | spark         | postgresql-k8s               | 14/stable     | 281      |
-| spark         | zookeeper-k8s                | 3/edge        | 75       |
+| spark         | zookeeper-k8s                | 3/stable      | 75       |
 | spark         | data-integrator              | latest/stable | 161      |
 | s3            | s3-integrator                | 1/stable      | 145      |
 

--- a/releases/3.5/terraform/main.tf
+++ b/releases/3.5/terraform/main.tf
@@ -52,6 +52,7 @@ module "spark" {
   metastore_image          = var.metastore_image != null ? var.metastore_image : local.images.metastore
   zookeeper_revision       = var.zookeeper_revision != null ? var.zookeeper_revision : local.revisions.zookeeper
   zookeeper_image          = var.zookeeper_image != null ? var.zookeeper_image : local.images.zookeeper
+  data_integrator_revision = var.data_integrator_revision != null ? var.data_integrator_revision : local.revisions.data_integrator
 }
 
 module "azure_storage" {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -121,6 +121,10 @@ resource "juju_application" "data_integrator" {
     revision = 161
   }
 
+  config = {
+    database-name = "integrator"
+  }
+
   units       = 1
   constraints = "arch=amd64"
 }

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -110,3 +110,17 @@ resource "juju_application" "zookeeper" {
   units       = var.zookeeper_units
   constraints = "arch=amd64"
 }
+
+resource "juju_application" "data-integrator" {
+  name  = "data-integrator"
+  model = data.juju_model.spark.name
+
+  charm {
+    name     = "data-integrator"
+    channel  = "latest/stable"
+    revision = 161
+  }
+
+  units       = 1
+  constraints = "arch-amd64"
+}

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -118,7 +118,7 @@ resource "juju_application" "data_integrator" {
   charm {
     name     = "data-integrator"
     channel  = "latest/stable"
-    revision = 161
+    revision = var.data_integrator_revision
   }
 
   config = {

--- a/releases/3.5/terraform/modules/spark/applications.tf
+++ b/releases/3.5/terraform/modules/spark/applications.tf
@@ -111,7 +111,7 @@ resource "juju_application" "zookeeper" {
   constraints = "arch=amd64"
 }
 
-resource "juju_application" "data-integrator" {
+resource "juju_application" "data_integrator" {
   name  = "data-integrator"
   model = data.juju_model.spark.name
 
@@ -122,5 +122,5 @@ resource "juju_application" "data-integrator" {
   }
 
   units       = 1
-  constraints = "arch-amd64"
+  constraints = "arch=amd64"
 }

--- a/releases/3.5/terraform/modules/spark/integrations.tf
+++ b/releases/3.5/terraform/modules/spark/integrations.tf
@@ -70,3 +70,18 @@ resource "juju_integration" "kyuubi_tls" {
     endpoint = var.tls_certificates_endpoint
   }
 }
+
+resource "juju_integration" "kyuubi_data_integrator" {
+  model = data.juju_model.spark.name
+
+  application {
+    name     = juju_application.kyuubi.name
+    endpoint = "jdbc"
+  }
+
+  application {
+    name     = juju_application.data_integrator.name
+    endpoint = "kyuubi"
+  }
+}
+

--- a/releases/3.5/terraform/modules/spark/variables.tf
+++ b/releases/3.5/terraform/modules/spark/variables.tf
@@ -106,3 +106,9 @@ variable "zookeeper_image" {
   type        = map(string)
   nullable    = false
 }
+
+variable "data_integrator_revision" {
+  description = "Charm revision for data-integrator"
+  type        = number
+  nullable    = false
+}

--- a/releases/3.5/terraform/variables.tf
+++ b/releases/3.5/terraform/variables.tf
@@ -185,6 +185,12 @@ variable "zookeeper_image" {
   default     = null
 }
 
+variable "data_integrator_revision" {
+  description = "Charm revision for data-integrator"
+  type        = number
+  default     = null
+}
+
 variable "s3_revision" {
   description = "Charm revision for s3-integrator"
   type        = number

--- a/releases/3.5/terraform/versions.tf
+++ b/releases/3.5/terraform/versions.tf
@@ -12,24 +12,25 @@ terraform {
 
 locals {
   revisions = {
-    spark_history_server  = 40
-    spark_integration_hub = 49
-    kyuubi                = 72
-    kyuubi_users          = 281
-    metastore             = 281
-    zookeeper             = 75
-    s3                    = 77
-    azure_storage         = 12
-    grafana_agent         = 104
-    cos_configuration     = 67
-    pushgateway           = 16
-    scrape_config         = 64
+    history_server    = 40
+    integration_hub   = 49
+    kyuubi            = 87
+    kyuubi_users      = 281
+    metastore         = 281
+    zookeeper         = 75
+    data_integrator   = 161
+    s3                = 77
+    azure_storage     = 12
+    grafana_agent     = 104
+    cos_configuration = 67
+    pushgateway       = 16
+    scrape_config     = 64
   }
   images = {
-    spark_history_server = {
+    history_server = {
       spark-history-server-image = "ghcr.io/canonical/charmed-spark@sha256:04727c07bd7ce9b244cf38376e6deb7acd7eabe5579d5f043c8b4af1aa9d79a4"
     } # 3.5.1
-    spark_integration_hub = {
+    integration_hub = {
       integration-hub-image = 5
     }
     kyuubi = {

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 73
+    revision: 85
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 72
+    revision: 73
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
@@ -73,6 +73,12 @@ applications:
     scale: 1
     constraints: arch=amd64
     trust: true
+  data-integrator:
+    charm: data-integrator
+    channel: latest/stable
+    revision: 161
+    scale: 1
+    constraints: arch=amd64
 relations:
 - - integration-hub:azure-storage-credentials
   - azure-storage:azure-storage-credentials
@@ -86,3 +92,5 @@ relations:
   - integration-hub:spark-service-account
 - - kyuubi:zookeeper
   - zookeeper:zookeeper
+- - kyuubi:jdbc
+  - data-integrator:kyuubi

--- a/releases/3.5/yaml/bundle-azure-storage.yaml.j2
+++ b/releases/3.5/yaml/bundle-azure-storage.yaml.j2
@@ -79,6 +79,8 @@ applications:
     revision: 161
     scale: 1
     constraints: arch=amd64
+    options:
+      database-name: integrator
 relations:
 - - integration-hub:azure-storage-credentials
   - azure-storage:azure-storage-credentials

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -86,6 +86,8 @@ applications:
     revision: 161
     scale: 1
     constraints: arch=amd64
+    options:
+      database-name: integrator
 relations:
 - - integration-hub:s3-credentials
   - s3:s3-credentials

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 73
+    revision: 85
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3

--- a/releases/3.5/yaml/bundle.yaml.j2
+++ b/releases/3.5/yaml/bundle.yaml.j2
@@ -6,7 +6,7 @@ applications:
   kyuubi:
     charm: kyuubi-k8s
     channel: latest/edge
-    revision: 72
+    revision: 73
     resources:
       kyuubi-image: ghcr.io/canonical/charmed-spark-kyuubi@sha256:29c84e1693ce7b5e6cf4fcb84570a79357f9bc1e66bce59d2e0031f1314699e5 # 3.4.4-1.10.1-22.04_edge 2025-05-06
     scale: 3
@@ -80,6 +80,12 @@ applications:
     scale: 1
     constraints: arch=amd64
     trust: true
+  data-integrator:
+    charm: data-integrator
+    channel: latest/stable
+    revision: 161
+    scale: 1
+    constraints: arch=amd64
 relations:
 - - integration-hub:s3-credentials
   - s3:s3-credentials
@@ -95,3 +101,5 @@ relations:
   - zookeeper:zookeeper
 - - kyuubi:certificates
   - certificates:certificates
+- - kyuubi:jdbc
+  - data-integrator:kyuubi


### PR DESCRIPTION
## Changes

- Bump kyuubi to revision 73+ (85 for a bug fix)  that removes `get-jdbc-endpoint` by adding data-integrator to the bundle
- Adapt integration tests
- Prepare action-based property management system removal from integration hub

TODO:
- ~~Fix docs in discourse~~ done