### PR TITLE
[MISC] Add `spark-service-account` and `metastore` offers in 3.5 terraform bundle

### DIFF
--- a/releases/3.5/terraform/modules/spark/offers.tf
+++ b/releases/3.5/terraform/modules/spark/offers.tf
@@ -1,0 +1,11 @@
+resource "juju_offer" "integration_hub" {
+  model            = data.juju_model.spark.name
+  application_name = juju_application.integration_hub.name
+  endpoints        = ["spark-service-account"]
+}
+
+resource "juju_offer" "metastore" {
+  model            = data.juju_model.spark.name
+  application_name = juju_application.metastore.name
+  endpoints        = ["database"]
+}


### PR DESCRIPTION
terraform validate and apply for 3.5 release were failing because of missing offers. Copied ones from 3.4 release