### PR TITLE
[MISC] Pin cos-configuration-k8s to rev65 on YAML bundle

### DIFF
--- a/releases/3.4/yaml/overlays/cos-integration.yaml.j2
+++ b/releases/3.4/yaml/overlays/cos-integration.yaml.j2
@@ -26,9 +26,10 @@ applications:
   cos-configuration:
     charm: cos-configuration-k8s
     channel: 1/stable
-    # TODO: bump the revision to 1/stable when the following issue gets fixed:
+    # TODO: bump the revision to 1/stable when both of the following issue gets fixed:
     # https://github.com/canonical/cos-configuration-k8s-operator/issues/128 
-    revision: 69
+    # https://github.com/canonical/cos-configuration-k8s-operator/issues/84
+    revision: 65
     base: ubuntu@20.04/stable
     resources:
       git-sync-image: 35

--- a/releases/3.5/yaml/overlays/cos-integration.yaml.j2
+++ b/releases/3.5/yaml/overlays/cos-integration.yaml.j2
@@ -26,9 +26,10 @@ applications:
   cos-configuration:
     charm: cos-configuration-k8s
     channel: 1/stable
-    # TODO: bump the revision to 1/stable when the following issue gets fixed:
+    # TODO: bump the revision to 1/stable when both of the following issue gets fixed:
     # https://github.com/canonical/cos-configuration-k8s-operator/issues/128 
-    revision: 69
+    # https://github.com/canonical/cos-configuration-k8s-operator/issues/84
+    revision: 65
     base: ubuntu@20.04/stable
     resources:
       git-sync-image: 35


### PR DESCRIPTION
Earlier [we pinned this in Terraform bundle](https://github.com/canonical/spark-k8s-bundle/pull/142), but since we have 1 test involving YAML, that was failing recently. To improve stability, now we want to pin this in YAML bundle as well.

Revision 65 is pinned because of the following two issues in `cos-configuration-k8s`:
 https://github.com/canonical/cos-configuration-k8s-operator/issues/128 
 https://github.com/canonical/cos-configuration-k8s-operator/issues/84