### PR TITLE
[MISC] Fix typo for creating a folder instead of file

### DIFF
--- a/docs/how-to/deploy/environment.md
+++ b/docs/how-to/deploy/environment.md
@@ -484,7 +484,7 @@ The endpoint of the service is `https://s3.<S3_REGION>.amazonaws.com`.
 To create a folder on an existing bucket, just place an empty path object `spark-events`:
 
 ```shell
-aws s3api put-object --bucket <S3_BUCKET> --key spark-events
+aws s3api put-object --bucket <S3_BUCKET> --key spark-events/
 ```
 
 The S3-object storage should now be ready to be used by Spark jobs to store their logs. 


### PR DESCRIPTION
## Description

When I tried to copy and paste this command, I realized that this was creating a file instead of a folder, and as a consequence the spark processes were failing with the error 

```
java.lang.IllegalArgumentException: Log directory s3a://spark-test/spark-events is not a directory.
```

## Checklist

- [x] I have added or updated any relevant documentation.
