### PR TITLE
[PRA-232] Pinning Juju 3.6.14 in CI

### DIFF
--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -150,6 +150,7 @@ runs:
         cd ..
 
     - name: Patch juju installation
+      shell: bash
       run: |
         sudo snap install yq
         CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -115,7 +115,7 @@ runs:
         juju-channel: ${{ inputs.juju-snap-channel }}
         provider: microk8s
         channel: "${{ inputs.k8s-version }}-strict/stable"
-        bootstrap-options: "--agent-version ${{ inputs.juju-agent-version }}"
+        bootstrap-options: "--agent-version 3.6.19"
         microk8s-group: snap_microk8s
         microk8s-addons: "hostpath-storage rbac dns metallb:10.64.140.43-10.64.140.49"
 

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -144,7 +144,7 @@ runs:
         # Set the versions
         yq -i e '.providers.k8s.channel = "${{ inputs.k8s-version }}-classic/stable"' concierge.yaml
         yq -i e '.juju.channel = "${{ inputs.juju-snap-channel }}"' concierge.yaml
-        yq -i e '.juju.agent-version = "${{ inputs.juju-agent-version }}"' concierge.yaml
+        yq -i e '.juju.agent-version = "3.6.19"' concierge.yaml
         
         sudo concierge prepare --trace
         cd ..

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -156,7 +156,18 @@ runs:
         CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
         juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
         sudo snap refresh juju --revision 33784
+
+    - name: Re-install controller (MicroK8s)
+      shell: bash
+      if: "${{ inputs.k8s-distribution == 'microk8s' }}"
+      run: |
         sudo -i -u ubuntu juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ inputs.juju-agent-version }}"
+
+    - name: Re-install controller (K8s)
+      shell: bash
+      if: "${{ inputs.k8s-distribution == 'k8s' }}"
+      run: |
+        sudo -u ubuntu juju bootstrap k8s $CONTROLLER_NAME --verbose --agent-version "${{ inputs.juju-agent-version }}" --model-default 'logging-config=<root>=INFO; unit=DEBUG' --bootstrap-constraints root-disk=4G
 
     - id: setup-python
       name: Setup Python

--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -149,6 +149,14 @@ runs:
         sudo concierge prepare --trace
         cd ..
 
+    - name: Patch juju installation
+      run: |
+        sudo snap install yq
+        CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
+        juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
+        sudo snap refresh juju --revision 33784
+        sudo -i -u ubuntu juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ inputs.juju-agent-version }}"
+
     - id: setup-python
       name: Setup Python
       uses: actions/setup-python@v5.0.0

--- a/.github/workflows/ci-tests-full.yaml
+++ b/.github/workflows/ci-tests-full.yaml
@@ -46,19 +46,19 @@ jobs:
           - juju-snap-channel: "3.5/stable"
             juju-agent-version: "3.5.6"
           - juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
 
           # Test integration-basic, with Spark 3.4
           - tox-env: integration-basic
             spark-version: 3.4.4
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
 
           # Test integration-basic, with Spark 3.5
           - tox-env: integration-basic
             spark-version: 3.5.7
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
 
         exclude:
           # Backup / Restore tests only supported on Terraform

--- a/.github/workflows/ci-tests-minimal.yaml
+++ b/.github/workflows/ci-tests-minimal.yaml
@@ -27,7 +27,7 @@ jobs:
         spark-version: [ "3.4.4", "3.5.7" ]
         storage-backend: [ "s3", "azure_storage" ]
         juju-snap-channel: [ "3.6/stable" ]
-        juju-agent-version: [ "3.6.19" ]
+        juju-agent-version: [ "3.6.14" ]
         k8s-distribution: ["k8s", "microk8s"]
         k8s-version:
           - "1.32"
@@ -39,7 +39,7 @@ jobs:
           - tox-env: integration-basic
             spark-version: 3.4.4
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             k8s-distribution: "k8s"
             k8s-version: "1.32"
 
@@ -47,7 +47,7 @@ jobs:
           - tox-env: integration-basic
             spark-version: 3.5.7
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             k8s-distribution: "k8s"
             k8s-version: "1.32"
 
@@ -58,7 +58,7 @@ jobs:
             storage-backend: s3
             spark-version: 3.4.4
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             k8s-distribution: "k8s"
             k8s-version: "1.32"
 
@@ -67,7 +67,7 @@ jobs:
             bundle-backend: terraform
             storage-backend: s3
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             cos-model: cos
 
           # Test COS just once with integration-kyuubi
@@ -75,7 +75,7 @@ jobs:
             bundle-backend: terraform
             storage-backend: s3
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             cos-model: cos
 
           # Test COS just once with integration-backup-restore
@@ -83,7 +83,7 @@ jobs:
             bundle-backend: terraform
             storage-backend: s3
             juju-snap-channel: "3.6/stable"
-            juju-agent-version: "3.6.19"
+            juju-agent-version: "3.6.14"
             cos-model: cos
 
     needs:

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup tmate session
+        if: false
         uses: canonical/action-tmate@main
         with:
           detached: true

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -52,7 +52,7 @@ jobs:
           juju-channel: ${{ matrix.juju.snap_channel }}
           provider: microk8s
           channel: "${{ matrix.k8s-version }}-strict/stable"
-          bootstrap-options: "--agent-version ${{ matrix.juju.agent }}"
+          # bootstrap-options: "--agent-version ${{ matrix.juju.agent }}"
           microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage rbac dns metallb:10.64.140.43-10.64.140.49"
       - name: Patch juju installation

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -61,7 +61,7 @@ jobs:
           CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
           juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
           sudo snap refresh juju --revision 33784
-          juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
+          sudo juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
 
       - name: Install tox & poetry
         run: |

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           sudo snap install yq
           CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
-          juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt
+          juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
           sudo snap refresh juju --revision 33784
           juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
 

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -24,15 +24,15 @@ jobs:
           - terraform
         storage-backend:
           - s3
-        #  - azure_storage
+          - azure_storage
         juju:
           - snap_channel: "3.6/stable"
             agent: "3.6.14"
         k8s-version:
-        #   - "1.28"
+          - "1.28"
           - "1.30"
-        #   - "1.32"
-        #   - "1.34"
+          - "1.32"
+          - "1.34"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -24,15 +24,15 @@ jobs:
           - terraform
         storage-backend:
           - s3
-          - azure_storage
+        #  - azure_storage
         juju:
           - snap_channel: "3.6/stable"
             agent: "3.6.19"
         k8s-version:
-          - "1.28"
+        #   - "1.28"
           - "1.30"
-          - "1.32"
-          - "1.34"
+        #   - "1.32"
+        #   - "1.34"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -27,7 +27,7 @@ jobs:
         #  - azure_storage
         juju:
           - snap_channel: "3.6/stable"
-            agent: "3.6.19"
+            agent: "3.6.14"
         k8s-version:
         #   - "1.28"
           - "1.30"
@@ -55,6 +55,14 @@ jobs:
           bootstrap-options: "--agent-version ${{ matrix.juju.agent }}"
           microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage rbac dns metallb:10.64.140.43-10.64.140.49"
+      - name: Patch juju installation
+        run: |
+          sudo snap install yq
+          CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
+          juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt
+          sudo snap refresh juju --revision 33784
+          juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
+
       - name: Install tox & poetry
         run: |
           pip install tox

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -36,11 +36,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-      - name: Setup tmate session
-        if: false
-        uses: canonical/action-tmate@main
-        with:
-          detached: true
       - id: setup-python
         name: Setup Python
         uses: actions/setup-python@v5.0.0

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -36,6 +36,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+        with:
+          detached: true
       - id: setup-python
         name: Setup Python
         uses: actions/setup-python@v5.0.0

--- a/.github/workflows/ci-uat.yaml
+++ b/.github/workflows/ci-uat.yaml
@@ -61,7 +61,7 @@ jobs:
           CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
           juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
           sudo snap refresh juju --revision 33784
-          sudo juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
+          sudo -i -u ubuntu juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ matrix.juju.agent }}"
 
       - name: Install tox & poetry
         run: |

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,10 +8,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
+  workflow_dispatch:
+
+  # pull_request:
+  #   paths-ignore:
+  #     - 'docs/**'
+  #    - '**.md'
 
 jobs:
   tests:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,10 +10,10 @@ concurrency:
 on:
   workflow_dispatch:
 
-  # pull_request:
-  #   paths-ignore:
-  #     - 'docs/**'
-  #    - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   tests:


### PR DESCRIPTION
## Description

Current PR workarounds the current limitation of not being able to bootstrap controller previous of 3.6.18 with the latest snap. Therefore, after setting up the environment, we destroy controller and refresh the snap to a previous revisions. We then bootstrap a new controller
