### PR TITLE
[MISC] chore: unpin Juju version

### DIFF
--- a/.github/actions/run-test/action.yaml
+++ b/.github/actions/run-test/action.yaml
@@ -149,26 +149,6 @@ runs:
         sudo concierge prepare --trace
         cd ..
 
-    - name: Patch juju installation
-      shell: bash
-      run: |
-        sudo snap install yq
-        CONTROLLER_NAME=$(juju controllers --format yaml | yq .current-controller)
-        juju destroy-controller $CONTROLLER_NAME --destroy-storage --no-prompt --destroy-all-models
-        sudo snap refresh juju --revision 33784
-
-    - name: Re-install controller (MicroK8s)
-      shell: bash
-      if: "${{ inputs.k8s-distribution == 'microk8s' }}"
-      run: |
-        sudo -i -u ubuntu juju bootstrap microk8s $CONTROLLER_NAME --agent-version "${{ inputs.juju-agent-version }}"
-
-    - name: Re-install controller (K8s)
-      shell: bash
-      if: "${{ inputs.k8s-distribution == 'k8s' }}"
-      run: |
-        sudo -u ubuntu juju bootstrap k8s $CONTROLLER_NAME --verbose --agent-version "${{ inputs.juju-agent-version }}" --model-default 'logging-config=<root>=INFO; unit=DEBUG' --bootstrap-constraints root-disk=4G
-
     - id: setup-python
       name: Setup Python
       uses: actions/setup-python@v5.0.0


### PR DESCRIPTION
## Description

Given the recent release of juju 3.6.23 that has improved the removal of resources, we can now unpin the Juju version on the CI

## Checklist

- [ ] I have added or updated any relevant documentation.
