### PR TITLE
docs: Add GH workflow for tutorial tests

### DIFF
--- a/.github/workflows/tutorial-tests.yaml
+++ b/.github/workflows/tutorial-tests.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Tutorial tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 3 2 * *'  # 2nd of every month at 03:00 UTC
+
+jobs:
+  tutorial-test:
+    name: Tutorial end-to-end
+    runs-on: [self-hosted, linux, AMD64, X64, xlarge, noble]
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check KVM availability
+        run: |
+          if [[ ! -e /dev/kvm ]]; then
+            echo "::error::KVM is not available on this runner. Multipass requires KVM for VM creation."
+            exit 1
+          fi
+
+      - name: Install Multipass
+        run: |
+          if ! command -v multipass &>/dev/null; then
+            sudo snap install multipass
+          fi
+
+      - name: Install Go and Spread
+        run: |
+          if ! command -v go &>/dev/null; then
+            sudo snap install go --classic
+          fi
+          go install github.com/canonical/spread/cmd/spread@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: Install tox
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pipx
+          pipx install tox
+
+      - name: Run tutorial tests
+        run: tox -e tutorial
+        working-directory: python
+
+      - name: Cleanup Multipass VM
+        if: always()
+        run: |
+          multipass delete --purge spark-tutorial-vm 2>/dev/null || true


### PR DESCRIPTION
## Description

This is to make tutorial tests to run:

- When triggered by other workflows (for example, release or risk promotion)
- When manually triggered by a button on GH
- Once in a while on schedule (monthly in this particular case, but we can easily adjust) - just to detect an unexpected regression

Beased on the [Kafka GH workflow](https://github.com/canonical/kafka-operator/blob/main/.github/workflows/tutorial-tests.yaml).

## Checklist

- [x] I have added or updated any relevant documentation.
