### PR TITLE
[PRA-318] Implement automated OCI getter for our products

### DIFF
--- a/terraform/charms/azure-storage-integrator/README.md
+++ b/terraform/charms/azure-storage-integrator/README.md
@@ -16,7 +16,7 @@ To be contributed upstream.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 
 ### Modules
 

--- a/terraform/charms/s3-integrator/README.md
+++ b/terraform/charms/s3-integrator/README.md
@@ -16,7 +16,7 @@ To be contributed upstream.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 
 ### Modules
 
@@ -36,7 +36,7 @@ No modules.
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application. | `string` | `"s3-integrator"` | no |
 | <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy. E.g. ubuntu@22.04. | `string` | `null` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel of the charm. | `string` | `"2/stable"` | no |
-| <a name="input_config"></a> [config](#input\_config) | Map for configuration options. | <pre>object({<br/>    attributes                          = optional(string)<br/>    bucket                              = optional(string)<br/>    credentials                         = optional(string)<br/>    endpoint                            = optional(string)<br/>    experimental-delete-older-than-days = optional(number)<br/>    path                                = optional(string)<br/>    region                              = optional(string)<br/>    s3-api-version                      = optional(string)<br/>    s3-uri-style                        = optional(string)<br/>    storage-class                       = optional(string)<br/>    tls-ca-chain                        = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_config"></a> [config](#input\_config) | Map for configuration options. | <pre>object({<br/>    attributes                          = optional(string)<br/>    bucket                              = optional(string)<br/>    endpoint                            = optional(string)<br/>    experimental-delete-older-than-days = optional(number)<br/>    path                                = optional(string)<br/>    region                              = optional(string)<br/>    s3-api-version                      = optional(string)<br/>    s3-uri-style                        = optional(string)<br/>    storage-class                       = optional(string)<br/>    tls-ca-chain                        = optional(string)<br/>    credentials                         = optional(string)<br/>  })</pre> | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application. | `string` | `null` | no |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model uuid. | `string` | n/a | yes |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm. | `number` | `null` | no |

--- a/terraform/charms/zookeeper/README.md
+++ b/terraform/charms/zookeeper/README.md
@@ -16,7 +16,7 @@ To be contributed upstream.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 
 ### Modules
 

--- a/terraform/components/kyuubi/README.md
+++ b/terraform/components/kyuubi/README.md
@@ -40,3 +40,60 @@ The kyuubi component module provides a complete deployment of the Kyuubi SQL eng
 - `requires`: Map of the requires endpoints
 - `provides`: Map of the provides endpoints
 - `offers`: Map of all offers exposed by the component's charms
+
+<!-- BEGIN_TF_DOCS -->
+### Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.0.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >=1.4.0 |
+
+### Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.4.0 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+| ---- | ---- |
+| [juju_application.kyuubi](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_integration.kyuubi_certificates](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.kyuubi_data_integrator](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.kyuubi_metastore](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.kyuubi_service_account](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.kyuubi_users_db](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.kyuubi_zookeeper](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_offer.kyuubi_jdbc](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
+| [juju_charm.kyuubi](https://registry.terraform.io/providers/juju/juju/latest/docs/data-sources/charm) | data source |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_certificates"></a> [certificates](#input\_certificates) | External integration for the certificate provider application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_data_integrator"></a> [data\_integrator](#input\_data\_integrator) | External integration for the data-integrator application | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_kyuubi"></a> [kyuubi](#input\_kyuubi) | n/a | <pre>object({<br/>    app_name    = optional(string, "kyuubi")<br/>    base        = optional(string, "ubuntu@22.04")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    resources   = optional(map(any))<br/>    revision    = optional(number)<br/>    track       = optional(string, "3.4")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
+| <a name="input_metastore"></a> [metastore](#input\_metastore) | External integration for the metastore (postgresql-k8s) application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model uuid. | `string` | n/a | yes |
+| <a name="input_risk"></a> [risk](#input\_risk) | Component's charms risk channel | `string` | `"stable"` | no |
+| <a name="input_spark_service_account"></a> [spark\_service\_account](#input\_spark\_service\_account) | External integration for the object storage integrator application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_users_db"></a> [users\_db](#input\_users\_db) | External integration for the Kyuubi users database (postgresql-k8s) application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_zookeeper"></a> [zookeeper](#input\_zookeeper) | External integration for the ZooKeeper application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+
+### Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_application"></a> [application](#output\_application) | Object representing the deployed Kyuubi application. |
+| <a name="output_components"></a> [components](#output\_components) | Map of the deployed applications for this component module. |
+| <a name="output_offers"></a> [offers](#output\_offers) | Map of all offers exposed by the component's charms. |
+| <a name="output_provides"></a> [provides](#output\_provides) | Map of all the provides endpoints. |
+| <a name="output_requires"></a> [requires](#output\_requires) | Map of the requires endpoints. |
+<!-- END_TF_DOCS -->

--- a/terraform/components/kyuubi/applications.tf
+++ b/terraform/components/kyuubi/applications.tf
@@ -6,15 +6,15 @@ resource "juju_application" "kyuubi" {
   model_uuid = var.model_uuid
 
   charm {
-    name     = "kyuubi-k8s"
-    base     = var.kyuubi.base
-    channel  = "${var.kyuubi.track}/${var.risk}"
-    revision = var.kyuubi.revision
+    name     = local.resolved_application.charm
+    base     = local.resolved_application.base
+    channel  = local.resolved_application.channel
+    revision = local.resolved_application.revision
   }
 
   config      = var.kyuubi.config
   units       = var.kyuubi.units
-  constraints = var.kyuubi.constraints
-  resources   = var.kyuubi.resources
+  constraints = local.resolved_application.constraints
+  resources   = local.resolved_application.resources
   trust       = true
 }

--- a/terraform/components/kyuubi/locals.tf
+++ b/terraform/components/kyuubi/locals.tf
@@ -1,0 +1,37 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  application = {
+    charm              = "kyuubi-k8s"
+    base               = var.kyuubi.base
+    track              = var.kyuubi.track
+    constraints        = var.kyuubi.constraints
+    architecture       = try(split(" ", split("arch=", var.kyuubi.constraints)[1])[0], "amd64")
+    revision_override  = var.kyuubi.revision
+    resource_overrides = var.kyuubi.resources != null ? var.kyuubi.resources : {}
+  }
+
+  resolved_application = merge(
+    local.application,
+    {
+      channel  = "${local.application.track}/${var.risk}"
+      revision = coalesce(local.application.revision_override, data.juju_charm.kyuubi.revision)
+      resources = merge(
+        {
+          for resource_name, resource_revision in data.juju_charm.kyuubi.resources :
+          resource_name => tonumber(resource_revision)
+        },
+        local.application.resource_overrides
+      )
+    }
+  )
+}
+
+data "juju_charm" "kyuubi" {
+  charm        = local.application.charm
+  base         = local.application.base
+  channel      = "${local.application.track}/${var.risk}"
+  architecture = local.application.architecture
+  revision     = local.application.revision_override
+}

--- a/terraform/components/kyuubi/terraform.tf
+++ b/terraform/components/kyuubi/terraform.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">=1.0.0"
+      version = ">=1.4.0"
     }
   }
 }

--- a/terraform/components/observability/README.md
+++ b/terraform/components/observability/README.md
@@ -23,7 +23,7 @@ As such, it is easier to define our own component module for now.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 
 ### Modules
 

--- a/terraform/components/spark-core/README.md
+++ b/terraform/components/spark-core/README.md
@@ -23,3 +23,53 @@ The spark-core module provides the core components for the Spark ecosystem, incl
 - `requires`: Map of the requires endpoints
 - `provides`: Map of the provides endpoints
 - `offers`: Map of all offers exposed by the component's charms
+
+<!-- BEGIN_TF_DOCS -->
+### Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.0.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >=1.4.0 |
+
+### Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.4.0 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+| ---- | ---- |
+| [juju_application.history_server](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_application.integration_hub](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_integration.history_server_object_storage](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.integration_hub_object_storage](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_offer.integration_hub_service_account](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/offer) | resource |
+| [juju_charm.spark](https://registry.terraform.io/providers/juju/juju/latest/docs/data-sources/charm) | data source |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_history_server"></a> [history\_server](#input\_history\_server) | n/a | <pre>object({<br/>    app_name    = optional(string, "history-server")<br/>    base        = optional(string, "ubuntu@22.04")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    resources   = optional(map(any))<br/>    revision    = optional(number)<br/>    track       = optional(string, "3")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
+| <a name="input_integration_hub"></a> [integration\_hub](#input\_integration\_hub) | n/a | <pre>object({<br/>    app_name    = optional(string, "integration-hub")<br/>    base        = optional(string, "ubuntu@22.04")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    resources   = optional(map(any))<br/>    revision    = optional(number)<br/>    track       = optional(string, "3")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model uuid. | `string` | n/a | yes |
+| <a name="input_object_storage"></a> [object\_storage](#input\_object\_storage) | External integration for the object storage integrator application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
+| <a name="input_object_storage_interface"></a> [object\_storage\_interface](#input\_object\_storage\_interface) | The interface of the object storage backend. | `string` | n/a | yes |
+| <a name="input_risk"></a> [risk](#input\_risk) | Component's charms risk channel | `string` | `"stable"` | no |
+
+### Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_components"></a> [components](#output\_components) | Map of the deployed applications for this component module. |
+| <a name="output_offers"></a> [offers](#output\_offers) | Map of all offers exposed by the component's charms. |
+| <a name="output_provides"></a> [provides](#output\_provides) | Map of all the provides endpoints. |
+| <a name="output_requires"></a> [requires](#output\_requires) | Map of the requires endpoints. |
+<!-- END_TF_DOCS -->

--- a/terraform/components/spark-core/applications.tf
+++ b/terraform/components/spark-core/applications.tf
@@ -6,14 +6,15 @@ resource "juju_application" "history_server" {
   model_uuid = var.model_uuid
 
   charm {
-    name     = "spark-history-server-k8s"
-    channel  = "${var.history_server.track}/${var.risk}"
-    revision = var.history_server.revision
+    name     = local.resolved_applications.history_server.charm
+    base     = local.resolved_applications.history_server.base
+    channel  = local.resolved_applications.history_server.channel
+    revision = local.resolved_applications.history_server.revision
   }
 
   config      = var.history_server.config
-  constraints = var.history_server.constraints
-  resources   = var.history_server.resources != null ? var.history_server.resources : {}
+  constraints = local.resolved_applications.history_server.constraints
+  resources   = local.resolved_applications.history_server.resources
   units       = var.history_server.units
 }
 
@@ -22,14 +23,15 @@ resource "juju_application" "integration_hub" {
   model_uuid = var.model_uuid
 
   charm {
-    name     = "spark-integration-hub-k8s"
-    channel  = "${var.integration_hub.track}/${var.risk}"
-    revision = var.integration_hub.revision
+    name     = local.resolved_applications.integration_hub.charm
+    base     = local.resolved_applications.integration_hub.base
+    channel  = local.resolved_applications.integration_hub.channel
+    revision = local.resolved_applications.integration_hub.revision
   }
 
   config      = var.integration_hub.config
-  constraints = var.integration_hub.constraints
-  resources   = var.integration_hub.resources
+  constraints = local.resolved_applications.integration_hub.constraints
+  resources   = local.resolved_applications.integration_hub.resources
   trust       = true
   units       = var.integration_hub.units
 }

--- a/terraform/components/spark-core/locals.tf
+++ b/terraform/components/spark-core/locals.tf
@@ -1,0 +1,53 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  applications = {
+    history_server = {
+      charm              = "spark-history-server-k8s"
+      base               = var.history_server.base
+      track              = var.history_server.track
+      constraints        = var.history_server.constraints
+      architecture       = try(split(" ", split("arch=", var.history_server.constraints)[1])[0], "amd64")
+      revision_override  = var.history_server.revision
+      resource_overrides = var.history_server.resources != null ? var.history_server.resources : {}
+    }
+    integration_hub = {
+      charm              = "spark-integration-hub-k8s"
+      base               = var.integration_hub.base
+      track              = var.integration_hub.track
+      constraints        = var.integration_hub.constraints
+      architecture       = try(split(" ", split("arch=", var.integration_hub.constraints)[1])[0], "amd64")
+      revision_override  = var.integration_hub.revision
+      resource_overrides = var.integration_hub.resources != null ? var.integration_hub.resources : {}
+    }
+  }
+
+  resolved_applications = {
+    for app_name, app in local.applications :
+    app_name => merge(
+      app,
+      {
+        channel  = "${app.track}/${var.risk}"
+        revision = coalesce(app.revision_override, data.juju_charm.spark[app_name].revision)
+        resources = merge(
+          {
+            for resource_name, resource_revision in data.juju_charm.spark[app_name].resources :
+            resource_name => tonumber(resource_revision)
+          },
+          app.resource_overrides
+        )
+      }
+    )
+  }
+}
+
+data "juju_charm" "spark" {
+  for_each = local.applications
+
+  charm        = each.value.charm
+  base         = each.value.base
+  channel      = "${each.value.track}/${var.risk}"
+  architecture = each.value.architecture
+  revision     = each.value.revision_override
+}

--- a/terraform/components/spark-core/terraform.tf
+++ b/terraform/components/spark-core/terraform.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">=1.0.0"
+      version = ">=1.4.0"
     }
   }
 }

--- a/terraform/products/charmed-spark-3.4/README.md
+++ b/terraform/products/charmed-spark-3.4/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ### Modules
@@ -23,12 +23,12 @@
 | ---- | ------ | ------- |
 | <a name="module_azure_storage"></a> [azure\_storage](#module\_azure\_storage) | ../../charms/azure-storage-integrator | n/a |
 | <a name="module_data_integrator"></a> [data\_integrator](#module\_data\_integrator) | ../../charms/data-integrator | n/a |
+| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_kyuubi_users"></a> [kyuubi\_users](#module\_kyuubi\_users) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_metastore"></a> [metastore](#module\_metastore) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_observability"></a> [observability](#module\_observability) | ../../components/observability | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../charms/s3-integrator | n/a |
 | <a name="module_spark_core"></a> [spark\_core](#module\_spark\_core) | ../../components/spark-core | n/a |
-| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | rev586 |
 | <a name="module_zookeeper"></a> [zookeeper](#module\_zookeeper) | ../../charms/zookeeper | n/a |
 
@@ -37,9 +37,11 @@
 | Name | Type |
 | ---- | ---- |
 | [juju_access_secret.azure_storage_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
+| [juju_access_secret.s3_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_access_secret.system_users_and_private_key_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_model.spark](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_secret.azure_storage_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
+| [juju_secret.s3_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [juju_secret.system_users_and_private_key_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [terraform_data.deployed_at](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 

--- a/terraform/products/charmed-spark-3.4/main.tf
+++ b/terraform/products/charmed-spark-3.4/main.tf
@@ -186,16 +186,14 @@ module "spark_core" {
   risk       = var.spark_risk
 
   history_server = {
-    config      = var.history_server_config
-    constraints = "arch=amd64"
-    revision    = var.history_server_revision
-    resources   = var.history_server_image != null ? { spark-history-server-image = var.history_server_image } : {}
+    config    = var.history_server_config
+    revision  = var.history_server_revision
+    resources = var.history_server_image != null ? { spark-history-server-image = var.history_server_image } : null
   }
   integration_hub = {
-    config      = var.integration_hub_config
-    constraints = "arch=amd64"
-    revision    = var.integration_hub_revision
-    resources   = var.integration_hub_image != null ? { integration-hub-image = var.integration_hub_image } : null
+    config    = var.integration_hub_config
+    revision  = var.integration_hub_revision
+    resources = var.integration_hub_image != null ? { integration-hub-image = var.integration_hub_image } : null
   }
 
   # Integrations
@@ -232,11 +230,10 @@ module "kyuubi" {
       } : {},
       var.kyuubi_config
     )
-    constraints = "arch=amd64",
-    revision    = var.kyuubi_revision
-    resources   = var.kyuubi_image != null ? { kyuubi-image = var.kyuubi_image } : null
-    track       = "3.4"
-    units       = var.kyuubi_units
+    revision  = var.kyuubi_revision
+    resources = var.kyuubi_image != null ? { kyuubi-image = var.kyuubi_image } : null
+    track     = "3.4"
+    units     = var.kyuubi_units
   }
 
   # Integrations

--- a/terraform/products/charmed-spark-3.5/README.md
+++ b/terraform/products/charmed-spark-3.5/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ### Modules
@@ -23,12 +23,12 @@
 | ---- | ------ | ------- |
 | <a name="module_azure_storage"></a> [azure\_storage](#module\_azure\_storage) | ../../charms/azure-storage-integrator | n/a |
 | <a name="module_data_integrator"></a> [data\_integrator](#module\_data\_integrator) | ../../charms/data-integrator | n/a |
+| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_kyuubi_users"></a> [kyuubi\_users](#module\_kyuubi\_users) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_metastore"></a> [metastore](#module\_metastore) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_observability"></a> [observability](#module\_observability) | ../../components/observability | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../charms/s3-integrator | n/a |
 | <a name="module_spark_core"></a> [spark\_core](#module\_spark\_core) | ../../components/spark-core | n/a |
-| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | rev586 |
 | <a name="module_zookeeper"></a> [zookeeper](#module\_zookeeper) | ../../charms/zookeeper | n/a |
 
@@ -37,9 +37,11 @@
 | Name | Type |
 | ---- | ---- |
 | [juju_access_secret.azure_storage_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
+| [juju_access_secret.s3_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_access_secret.system_users_and_private_key_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_model.spark](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_secret.azure_storage_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
+| [juju_secret.s3_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [juju_secret.system_users_and_private_key_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [terraform_data.deployed_at](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 

--- a/terraform/products/charmed-spark-3.5/main.tf
+++ b/terraform/products/charmed-spark-3.5/main.tf
@@ -188,16 +188,14 @@ module "spark_core" {
   risk       = var.spark_risk
 
   history_server = {
-    config      = var.history_server_config
-    constraints = "arch=amd64"
-    revision    = var.history_server_revision
-    resources   = { spark-history-server-image = var.history_server_image }
+    config    = var.history_server_config
+    revision  = var.history_server_revision
+    resources = var.history_server_image != null ? { spark-history-server-image = var.history_server_image } : null
   }
   integration_hub = {
-    config      = var.integration_hub_config
-    constraints = "arch=amd64"
-    revision    = var.integration_hub_revision
-    resources   = { integration-hub-image = var.integration_hub_image }
+    config    = var.integration_hub_config
+    revision  = var.integration_hub_revision
+    resources = var.integration_hub_image != null ? { integration-hub-image = var.integration_hub_image } : null
   }
 
   # Integrations
@@ -233,11 +231,10 @@ module "kyuubi" {
       } : {},
       var.kyuubi_config
     )
-    constraints = "arch=amd64",
-    revision    = var.kyuubi_revision
-    resources   = { kyuubi-image = var.kyuubi_image }
-    track       = "3.5"
-    units       = var.kyuubi_units
+    revision  = var.kyuubi_revision
+    resources = var.kyuubi_image != null ? { kyuubi-image = var.kyuubi_image } : null
+    track     = "3.5"
+    units     = var.kyuubi_units
   }
 
   # Integrations

--- a/terraform/products/charmed-spark-4.0/README.md
+++ b/terraform/products/charmed-spark-4.0/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_juju"></a> [juju](#provider\_juju) | 1.3.1 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >=1.0.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ### Modules
@@ -23,12 +23,12 @@
 | ---- | ------ | ------- |
 | <a name="module_azure_storage"></a> [azure\_storage](#module\_azure\_storage) | ../../charms/azure-storage-integrator | n/a |
 | <a name="module_data_integrator"></a> [data\_integrator](#module\_data\_integrator) | ../../charms/data-integrator | n/a |
+| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_kyuubi_users"></a> [kyuubi\_users](#module\_kyuubi\_users) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_metastore"></a> [metastore](#module\_metastore) | git::https://github.com/canonical/postgresql-k8s-operator//terraform | rev774 |
 | <a name="module_observability"></a> [observability](#module\_observability) | ../../components/observability | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../charms/s3-integrator | n/a |
 | <a name="module_spark_core"></a> [spark\_core](#module\_spark\_core) | ../../components/spark-core | n/a |
-| <a name="module_kyuubi"></a> [kyuubi](#module\_kyuubi) | ../../components/kyuubi | n/a |
 | <a name="module_ssc"></a> [ssc](#module\_ssc) | git::https://github.com/canonical/self-signed-certificates-operator//terraform | rev586 |
 | <a name="module_zookeeper"></a> [zookeeper](#module\_zookeeper) | ../../charms/zookeeper | n/a |
 
@@ -37,9 +37,11 @@
 | Name | Type |
 | ---- | ---- |
 | [juju_access_secret.azure_storage_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
+| [juju_access_secret.s3_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_access_secret.system_users_and_private_key_secret_access](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/access_secret) | resource |
 | [juju_model.spark](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/model) | resource |
 | [juju_secret.azure_storage_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
+| [juju_secret.s3_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [juju_secret.system_users_and_private_key_secret](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/secret) | resource |
 | [terraform_data.deployed_at](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 

--- a/terraform/products/charmed-spark-4.0/main.tf
+++ b/terraform/products/charmed-spark-4.0/main.tf
@@ -188,17 +188,15 @@ module "spark_core" {
   risk       = var.spark_risk
 
   history_server = {
-    config      = var.history_server_config
-    constraints = "arch=amd64"
-    revision    = var.history_server_revision
-    resources   = { spark-history-server-image = var.history_server_image }
-    track       = "4"
+    config    = var.history_server_config
+    revision  = var.history_server_revision
+    resources = var.history_server_image != null ? { spark-history-server-image = var.history_server_image } : null
+    track     = "4"
   }
   integration_hub = {
-    config      = var.integration_hub_config
-    constraints = "arch=amd64"
-    revision    = var.integration_hub_revision
-    resources   = { integration-hub-image = var.integration_hub_image }
+    config    = var.integration_hub_config
+    revision  = var.integration_hub_revision
+    resources = var.integration_hub_image != null ? { integration-hub-image = var.integration_hub_image } : null
   }
 
   # Integrations
@@ -234,11 +232,10 @@ module "kyuubi" {
       } : {},
       var.kyuubi_config
     )
-    constraints = "arch=amd64",
-    revision    = var.kyuubi_revision
-    resources   = { kyuubi-image = var.kyuubi_image }
-    track       = "4.0"
-    units       = var.kyuubi_units
+    revision  = var.kyuubi_revision
+    resources = var.kyuubi_image != null ? { kyuubi-image = var.kyuubi_image } : null
+    track     = "4.0"
+    units     = var.kyuubi_units
   }
 
   # Integrations


### PR DESCRIPTION
This PR fixes the issue of making the OCI resources for our products mandatory. 

In addition, it adds a new setup that I find quite neat. Thanks to the "juju_charm" resource, we have some automation that:
-  picks latest charm revision on the track, with the latest oci resource
- if we just override the charm revision, then it automatically picks the corresponding oci resource
- allows to override charm revision and oci resource, or just the oci resource

Here are some results from my own tests:

- Without variables, we deploy the history server revision 98 and OCI rev 24
- When we pass `history_server_image="ghcr.io/canonical/charmed-spark@sha256:f7f387a76ba2f3b6cfc34a35f36c0f4ae85bfa78c8c9d4bfa06ba86401b95d70"`  we get the following plan
```
 # module.spark.module.spark_core.juju_application.history_server will be updated in-place
  ~ resource "juju_application" "history_server" {
        id          = "55cdab9f-9342-47a1-88ea-698499732018:history-server"
      ~ machines    = [] -> (known after apply)
        name        = "history-server"
      ~ resources   = {
          ~ "spark-history-server-image" = "24" -> "ghcr.io/canonical/charmed-spark@sha256:f7f387a76ba2f3b6cfc34a35f36c0f4ae85bfa78c8c9d4bfa06ba86401b95d70"
        }
      + storage     = (known after apply)
        # (6 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```
- When we pass `history_server_revision=117`, we get
```
 # module.spark.module.spark_core.juju_application.history_server will be updated in-place
  ~ resource "juju_application" "history_server" {
        id          = "55cdab9f-9342-47a1-88ea-698499732018:history-server"
      ~ machines    = [] -> (known after apply)
        name        = "history-server"
      ~ resources   = {
          ~ "spark-history-server-image" = "24" -> "29"
        }
      + storage     = (known after apply)
        # (6 unchanged attributes hidden)

      ~ charm {
            name     = "spark-history-server-k8s"
          ~ revision = 98 -> 117
            # (2 unchanged attributes hidden)
        }
    }
```
So we appropriately pick the proper oci resource
- When we pass both, we get
```
 # module.spark.module.spark_core.juju_application.history_server will be updated in-place
  ~ resource "juju_application" "history_server" {
        id          = "55cdab9f-9342-47a1-88ea-698499732018:history-server"
      ~ machines    = [] -> (known after apply)
        name        = "history-server"
      ~ resources   = {
          ~ "spark-history-server-image" = "24" -> "ghcr.io/canonical/charmed-spark@sha256:f7f387a76ba2f3b6cfc34a35f36c0f4ae85bfa78c8c9d4bfa06ba86401b95d70"
        }
      + storage     = (known after apply)
        # (6 unchanged attributes hidden)

      ~ charm {
            name     = "spark-history-server-k8s"
          ~ revision = 98 -> 117
            # (2 unchanged attributes hidden)
        }
    }
```

Perhaps something we can share with folks working on charm modules as well?

