### PR TITLE
[PRA-324] Adapt docs content to 3.5 track

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Charmed Apache Spark
 
 [![CharmHub Badge](https://charmhub.io/spark-k8s-bundle/badge.svg)](https://charmhub.io/spark-k8s-bundle)
-[![Tests](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests.yaml/badge.svg?branch=main)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests.yaml?query=branch%3Amain)
-[![Docs](https://readthedocs.com/projects/canonical-charmed-spark/badge/?version=main&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-spark/builds/?version__slug=main)
-<!-- [![Release](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-checks.yaml/badge.svg)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-checks.yaml) -->
+[![Tests](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests-full.yaml/badge.svg?branch=track/3.5)](https://github.com/canonical/spark-k8s-bundle/actions/workflows/ci-tests-full.yaml?query=branch%3Atrack/3.5)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-spark/badge/?version=3.5&style=plastic)](https://app.readthedocs.com/projects/canonical-charmed-spark/builds/?version__slug=3.5)
 
 Charmed Apache Spark is a solution that makes operating Apache Spark workloads on Kubernetes seamless, secure, and production-ready. This solution includes:
 
@@ -14,9 +13,7 @@ Charmed Apache Spark is a solution that makes operating Apache Spark workloads o
 This repository contains relevant artifacts for deploying and testing Charmed Apache Spark:
 
 * [python](./python) — contains the `spark-k8s-test` package that provides  utilities and fixtures to easily implement Charmed Apache Spark tests. Find more information in its [readme file](./python/README.md)
-* [releases](./releases) — contains the artifacts for the different channels, supporting the following backends:
-  * [yaml](./releases/3.4/yaml) — using Juju YAML bundles to easily deploy Charmed Apache Spark on K8s
-  * [terraform](releases/3.4/terraform) — using Terraform scripts to deploy Charmed Apache Spark using the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju)
+* [terraform](./terraform) — contains Terraform scripts to deploy Charmed Apache Spark using the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju)
 
 Charmed Apache Spark bundle is also available on [Charmhub](https://charmhub.io/spark-k8s-bundle).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ import yaml
 
 project = "Charmed Apache Spark"
 author = "Canonical Ltd."
+TRACK = "3.5"
 
 
 # Sidebar documentation title; best kept reasonably short
@@ -34,7 +35,7 @@ author = "Canonical Ltd."
 #
 # TODO: To disable the title, set to an empty string.
 
-html_title = project + " documentation"
+html_title = project + f" {TRACK} documentation"
 
 
 # Copyright string; shown at the bottom of the page

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,11 +136,9 @@ html_context = {
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
-    'repo_default_branch': 'main',
+    "repo_default_branch": "track/3.5",
     # Docs location in the repo; used in links for viewing the source files
     #
-
-
     # TODO: To customise the directory, uncomment and update as needed.
     "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
@@ -148,9 +146,8 @@ html_context = {
     # "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
-
-    # Required for feedback button    
-    'github_issues': 'enabled',
+    # Required for feedback button
+    "github_issues": "enabled",
 }
 
 # TODO: To enable the edit button on pages, uncomment and change the link to a
@@ -161,7 +158,7 @@ html_context = {
 # - https://git.launchpad.net/example
 
 html_theme_options = {
-'source_edit_link': 'https://github.com/canonical/spark-k8s-bundle',
+    "source_edit_link": "https://github.com/canonical/spark-k8s-bundle",
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
@@ -177,16 +174,16 @@ html_theme_options = {
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://canonical-charmed-spark.readthedocs-hosted.com/'
+html_baseurl = "https://canonical-charmed-spark.readthedocs-hosted.com/"
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
+if "READTHEDOCS_VERSION" in os.environ:
     version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
+    sitemap_url_scheme = "{version}{link}"
 else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+    sitemap_url_scheme = "MANUAL/{link}"
 
 # Include `lastmod` dates in the sitemap:
 
@@ -195,9 +192,9 @@ sitemap_show_lastmod = True
 # Exclude generated pages from the sitemap:
 
 sitemap_excludes = [
-    '404/',
-    'genindex/',
-    'search/',
+    "404/",
+    "genindex/",
+    "search/",
 ]
 
 # TODO: Add more pages to sitemap_excludes if needed. Wildcards are supported.
@@ -247,7 +244,7 @@ linkcheck_ignore = [
     "https://charmhub.io/spark-integration-hub-k8s/integrations#logging",
     "https://charmhub.io/kyuubi-k8s/actions#get-jdbc-endpoint",
     "https://developer.hashicorp.com/terraform/*",
-    ]
+]
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
@@ -307,15 +304,13 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-html_css_files = [
-	'cookie-banner.css'
-]
+html_css_files = ["cookie-banner.css"]
 
 
 # Adds custom JavaScript files, located under 'html_static_path'
 
 html_js_files = [
-	'js/bundle.js',
+    "js/bundle.js",
 ]
 
 
@@ -368,12 +363,15 @@ if "discourse_prefix" not in html_context and "discourse" in html_context:
 
 # Workaround for substitutions.yaml
 
-if os.path.exists('./reuse/substitutions.yaml'):
-    with open('./reuse/substitutions.yaml', 'r') as fd:
+if os.path.exists("./reuse/substitutions.yaml"):
+    with open("./reuse/substitutions.yaml", "r") as fd:
         myst_substitutions = yaml.safe_load(fd.read())
 
 # Add configuration for intersphinx mapping
 
 intersphinx_mapping = {
-    'starter-pack': ('https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest', None)
+    "starter-pack": (
+        "https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest",
+        None,
+    )
 }

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -8,7 +8,7 @@ myst:
 # Configuration management
 
 Apache Spark comes with a wide range of
-[configuration properties](https://archive.apache.org/dist/spark/docs/3.4.2/configuration.html#available-properties)
+[configuration properties](https://archive.apache.org/dist/spark/docs/3.5.8/configuration.html#available-properties)
 that can be fed into Apache Spark using a single property file, e.g. `spark.properties`, or by passing configuration
 values on the command line, as an argument to `spark-submit`, `pyspark` and `spark-shell`.
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -197,7 +197,7 @@ and mutate incoming HTTP(s) requests, fully-integrated with the Canonical Identi
 Refer to the [how-to enable authorization in the Spark history server](how-to-spark-history-server-auth) guide
 for more information. From a permission-wise point of view, white lists of authorized users
 can be provided using the Spark History Server
-[charm configuration option](https://charmhub.io/spark-history-server-k8s/configurations?channel=3.4/edge).
+[charm configuration option](https://charmhub.io/spark-history-server-k8s/configurations?channel=3/edge).
 
 #### Kyuubi JDBC endpoint
 

--- a/docs/how-to/enable-monitoring.md
+++ b/docs/how-to/enable-monitoring.md
@@ -166,7 +166,7 @@ Congratulations, the COS now monitors the two charms.
 The `cos-configuration-k8s` charm included in the bundle can be used to customize the Grafana dashboards and alert rules.
 If needed, we provide a [default dashboard](https://github.com/canonical/spark-k8s-bundle/tree/main/resources/grafana) as part
 of the bundle and dedicated dashboards for the [Spark History Server](https://github.com/canonical/spark-history-server-k8s-operator/tree/3/edge/src/grafana_dashboards)
-and [Charmed Apache Kyuubi](https://github.com/canonical/kyuubi-k8s-operator/tree/3.4/edge/src/grafana_dashboards) charms.
+and [Charmed Apache Kyuubi](https://github.com/canonical/kyuubi-k8s-operator/tree/3.5/edge/src/grafana_dashboards) charms.
 
 The `cos-configuration-k8s` charm syncs the content of a repository with the resources
 provided to Grafana, thus enabling versioning of the resource.
@@ -181,7 +181,7 @@ Save your alert rules and dashboard models in a Git repository (new or existing)
 
 For rule writing examples, see the
 [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) and
-[Charmed Apache Kyuubi K8s repository](https://github.com/canonical/kyuubi-k8s-operator/blob/3.4/edge/src/prometheus_alert_rules/prometheus.yaml).
+[Charmed Apache Kyuubi K8s repository](https://github.com/canonical/kyuubi-k8s-operator/blob/3.5/edge/src/prometheus_alert_rules/prometheus.yaml).
 
 Make sure to push your changes to the remote repository.
 

--- a/docs/tutorial/1-environment-setup.md
+++ b/docs/tutorial/1-environment-setup.md
@@ -571,7 +571,7 @@ juju status -m spark-integration-hub --format=json | jq -e '.applications."spark
 
 ## (Optional) Create a snapshot
 
-At this stage, you may want to create a [snapshot](https://documentation.ubuntu.com/multipass/en/latest/reference/command-line-interface/snapshot/#snapshot) of the current state, for which you need to stop the Multipass VM. Exit the VM by pressing `CTRL + D` and stop it:
+At this stage, you may want to create a [snapshot](https://canonical.com/multipass/docs/latest/reference/command-line-interface/snapshot) of the current state, for which you need to stop the Multipass VM. Exit the VM by pressing `CTRL + D` and stop it:
 
 ```bash
 multipass stop spark-tutorial

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -23,7 +23,7 @@ git clone https://github.com/canonical/spark-k8s-bundle.git
 cd spark-k8s-bundle/
 ```
 
-and run 
+and run
 
 ```bash
 poetry install
@@ -31,15 +31,15 @@ poetry install
 
 ## Developing
 
-When developing we advise you to use virtual environment to confine the installation of this package and its dependencies. Please refer to [venv](https://docs.python.org/3/library/venv.html), [pyenv](https://github.com/pyenv/pyenv) or [conda](https://docs.conda.io/en/latest/), for some tools that help you to create and manage virtual environments. 
-We also advise you to read how Poetry integrates with virtual environments [here](https://python-poetry.org/docs/managing-environments/).   
+When developing we advise you to use virtual environment to confine the installation of this package and its dependencies. Please refer to [venv](https://docs.python.org/3/library/venv.html), [pyenv](https://github.com/pyenv/pyenv) or [conda](https://docs.conda.io/en/latest/), for some tools that help you to create and manage virtual environments.
+We also advise you to read how Poetry integrates with virtual environments [here](https://python-poetry.org/docs/managing-environments/).
 
-The project uses [tox](https://tox.wiki/en/latest/) for running CI/CD pipelines. 
+The project uses [tox](https://tox.wiki/en/latest/) for running CI/CD pipelines.
 
 You can create an environment for development with `tox`:
 
 ```shell
-tox devenv -e integration
+tox devenv -e unit
 source venv/bin/activate
 ```
 
@@ -48,25 +48,20 @@ source venv/bin/activate
 Using tox you can also run several operations, such as
 
 ```shell
-tox run -e fmt           # update your code according to linting rules
-tox run -e lint          # code style
-tox run -e unit          # unit tests
-tox run -e integration   # integration tests
-tox run -e all-tests     # unit+integration tests
-tox                      # runs 'lint' and 'unit' environments
+tox run -e format                 # update your code according to linting rules
+tox run -e lint                   # code style
+tox run -e unit                   # unit tests
+tox run -e integration-<domain>   # <domain> integration tests
 ```
 
 ## Documentation
 
-Product documentation is stored in [Discourse](https://discourse.charmhub.io/t/charmed-spark-k8s-documentation/8963) and published on Charmhub and the Canonical website via Discourse API. 
-The documentation in this repository under the release folder (e.g. `releases/3.4/docs`) is a mirror synched by [Discourse Gatekeeper](https://github.com/canonical/discourse-gatekeeper), that takes care of automatically raising and updating a PR whenever changes to the content on Discourse are made.
-Although Discourse content can be edited directly, unless the modifications are trivial and obvious (typos, spellings, formatting) we generally recommend to follow a review process:
+Product documentation is hosted on [Read the Docs](https://canonical-charmed-spark.readthedocs-hosted.com/).
+To edit the documentation content, we recommend the following process:
 
-1. Create a branch (either in the main repo or in a fork) from the current `main` and modify documentation files as necessary.
-2. Raise a PR against the `main` to start the review process, and conduct the code review within the PR.
-3. Once the PR is approved and all comments are addressed, the PR should NOT be merged directly! All the modifications should be applied to Discourse manually. If needed, new Discourse topics can be created, and referenced in the navigation table of the main index file on Discourse.
-4. Discourse Gatekeeper will raise a new PR or add new commits to an open Discourse PR, tracking the `discourse-gatekeeper/migrate` branch. The [sync_docs.yaml](https://github.com/canonical/spark-k8s-bundle/blob/main/.github/workflows/sync_docs.yaml) GitHub Actions provides further details on the Gatekeeper integration that can be run (a) in a scheduled fashion every night; (b) as a part of pull request CI, and (c) can be triggered manually. If new topics are referenced in the main index file on Discourse, these will be added to `docs/index.md` and the new topics pulled from Discourse.
-5. Once Gatekeeper has raised a new or updated an existing PR, feel free to close the initial PR manually created in step 2, with a comment referring to the PR created by Gatekeeper. If the initial PR was referring to a ticket, add the ticket to either the title or the description of the GateKeeper PR.
+1. Create a branch (either in the main repository or in a fork) from the current `track/<major>.<minor>` branch and modify documentation files as necessary.
+2. Raise a PR against the previous `track/<major>.<minor>` branch to start the review process, and conduct the code review within the PR. A link to the preview build is accessible from the PR.
+3. Once the PR is approved and all comments are addressed, the PR can be merged. The Read the Docs automation handles building the documentation website from the branch and publishing it.
 
 ### Terminology
 
@@ -74,21 +69,22 @@ Apache®, [Apache Spark, Spark™](https://spark.apache.org/) and their respecti
 
 For documentation in this repository the following conventions are applied (see the table below).
 
-| Full form | Alternatives | Incorrect examples |
-| -------- | ------- | ------- |
-| Apache Spark | | Spark |
-| Charmed Apache Spark | | Charmed Spark |
-| Spark History Server | Apache Spark History Server | |
-| Spark jobs | | Spark Jobs |
-| Spark Driver | | |
-| Spark Executor | | |
-| Spark Context | | |
-| Integration Hub for Apache Spark | Integration Hub | Spark Integration Hub |
-| Client tools snap for Apache Spark | | Spark client snap, tools snap |
+| Full form                          | Alternatives                | Incorrect examples            |
+| ---------------------------------- | --------------------------- | ----------------------------- |
+| Apache Spark                       |                             | Spark                         |
+| Charmed Apache Spark               |                             | Charmed Spark                 |
+| Spark History Server               | Apache Spark History Server |                               |
+| Spark jobs                         |                             | Spark Jobs                    |
+| Spark Driver                       |                             |                               |
+| Spark Executor                     |                             |                               |
+| Spark Context                      |                             |                               |
+| Integration Hub for Apache Spark   | Integration Hub             | Spark Integration Hub         |
+| Client tools snap for Apache Spark |                             | Spark client snap, tools snap |
 
 The full form must be used at least once per page.
 The full form must be used at the first entry to the page’s headings, body of text, callouts, and graphics.
 For subsequent usage, the full form can be substituted by alternatives.
+
 ### Kubernetes Terminology
 
 When documenting Kubernetes concepts, follow the [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects) for API object capitalization:
@@ -103,6 +99,7 @@ Special cases:
 - **kubeconfig**: Use lowercase when referring to the configuration file (e.g., "update the kubeconfig file").
 - **KUBECONFIG**: Use uppercase when referring to the environment variable.
 - **Product names**: Capitalize properly (e.g., "Azure Kubernetes Service", "Amazon Elastic Kubernetes Service").
+
 ## Canonical Contributor Agreement
 
 Canonical welcomes contributions to Charmed Apache Spark. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.

--- a/python/spark_test/fixtures/pod.py
+++ b/python/spark_test/fixtures/pod.py
@@ -25,7 +25,7 @@ def admin_pod_name():
 @pytest.fixture(scope="module")
 def spark_version():
     """Spark version."""
-    return "3.4.4"
+    return "3.5.8"
 
 
 @pytest.fixture(scope="module")

--- a/python/spark_test/resources/templates/testpod.yaml
+++ b/python/spark_test/resources/templates/testpod.yaml
@@ -6,7 +6,7 @@ metadata:
   name: testpod
 spec:
   containers:
-  - image: ghcr.io/canonical/charmed-spark:3.4-22.04_edge
+  - image: ghcr.io/canonical/charmed-spark:3.5-22.04_edge
     name: spark
     ports:
     - containerPort: 18080

--- a/python/tests/integration/resources/main.tf
+++ b/python/tests/integration/resources/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">=1.0.0"
+      version = "1.5.4"
     }
   }
 }
@@ -228,7 +228,7 @@ module "cos" {
   count = var.cos_model_uuid == null ? 0 : 1
   # the source is pinned to the last commit on branch track/2 that's still compatible with Juju TF < 1.4.0. 
   # For more details, see this section in cos-lite docs: https://github.com/canonical/observability-stack/blob/track/2/terraform/cos-lite/README.md#provider--100--140
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=7448dadb996835c1c0ae1d79d2f435992652d410" 
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=7448dadb996835c1c0ae1d79d2f435992652d410"
   model_uuid   = var.cos_model_uuid
   internal_tls = false
 }

--- a/python/tests/integration/resources/main.tf
+++ b/python/tests/integration/resources/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "1.5.4"
+      version = ">=1.0.0"
     }
   }
 }
@@ -228,7 +228,7 @@ module "cos" {
   count = var.cos_model_uuid == null ? 0 : 1
   # the source is pinned to the last commit on branch track/2 that's still compatible with Juju TF < 1.4.0. 
   # For more details, see this section in cos-lite docs: https://github.com/canonical/observability-stack/blob/track/2/terraform/cos-lite/README.md#provider--100--140
-  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=7448dadb996835c1c0ae1d79d2f435992652d410"
+  source       = "git::https://github.com/canonical/observability-stack//terraform/cos-lite?ref=7448dadb996835c1c0ae1d79d2f435992652d410" 
   model_uuid   = var.cos_model_uuid
   internal_tls = false
 }

--- a/terraform/components/kyuubi/README.md
+++ b/terraform/components/kyuubi/README.md
@@ -12,7 +12,7 @@ The kyuubi component module provides a complete deployment of the Kyuubi SQL eng
 - `kyuubi`: Configuration object for Kyuubi application with the following attributes:
   - `app_name`: Name to give the deployed Kyuubi application (default: "kyuubi")
   - `base`: The operating system on which to deploy Kyuubi (default: "ubuntu@22.04")
-  - `track`: Track of the Kyuubi charm (default: "3.4")
+  - `track`: Track of the Kyuubi charm (default: "3.5")
   - `config`: Map for Kyuubi configuration options (default: {})
   - `constraints`: String listing constraints for the Kyuubi application (default: "arch=amd64")
   - `resources`: Resources to attach to the Kyuubi application (default: null)
@@ -79,7 +79,7 @@ No modules.
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_certificates"></a> [certificates](#input\_certificates) | External integration for the certificate provider application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_data_integrator"></a> [data\_integrator](#input\_data\_integrator) | External integration for the data-integrator application | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
-| <a name="input_kyuubi"></a> [kyuubi](#input\_kyuubi) | n/a | <pre>object({<br/>    app_name    = optional(string, "kyuubi")<br/>    base        = optional(string, "ubuntu@22.04")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    resources   = optional(map(any))<br/>    revision    = optional(number)<br/>    track       = optional(string, "3.4")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
+| <a name="input_kyuubi"></a> [kyuubi](#input\_kyuubi) | n/a | <pre>object({<br/>    app_name    = optional(string, "kyuubi")<br/>    base        = optional(string, "ubuntu@22.04")<br/>    config      = optional(map(string), {})<br/>    constraints = optional(string, "arch=amd64")<br/>    resources   = optional(map(any))<br/>    revision    = optional(number)<br/>    track       = optional(string, "3.5")<br/>    units       = optional(number, 1)<br/>  })</pre> | `{}` | no |
 | <a name="input_metastore"></a> [metastore](#input\_metastore) | External integration for the metastore (postgresql-k8s) application. | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | n/a | yes |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model uuid. | `string` | n/a | yes |
 | <a name="input_risk"></a> [risk](#input\_risk) | Component's charms risk channel | `string` | `"stable"` | no |

--- a/terraform/components/kyuubi/variables.tf
+++ b/terraform/components/kyuubi/variables.tf
@@ -9,7 +9,7 @@ variable "kyuubi" {
     constraints = optional(string, "arch=amd64")
     resources   = optional(map(any))
     revision    = optional(number)
-    track       = optional(string, "3.4")
+    track       = optional(string, "3.5")
     units       = optional(number, 1)
   })
   default = {}

--- a/terraform/products/charmed-spark/terraform.tf
+++ b/terraform/products/charmed-spark/terraform.tf
@@ -6,9 +6,8 @@ terraform {
 
   required_providers {
     juju = {
-      source = "juju/juju"
-      # TODO: Unpin juju<1.5.5 when https://github.com/juju/terraform-provider-juju/pull/1298 gets merged and released
-      version = ">=1.0.0,<1.5.5"
+      source  = "juju/juju"
+      version = ">=1.0.0"
     }
   }
 }


### PR DESCRIPTION
Our docs were using 3.4 as the reference in a few places, so I changed that.
The contributing guide was also outdated

I also reverted the terraform provider pin since we no longer need it