### PR TITLE
[PRA-324] Update renovate configuration (3.5)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,9 +8,18 @@
     "theoctober19th",
     "batalex",
   ],
+  "baseBranchPatterns": ["/^track\\/[0-9]+\\.[0-9]+$/"],
   "schedule": ["* 3 * * 5"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["* 3 * * 5"]
   },
+  "ignoreDeps": ["ubuntu"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "enabled": false
+    }
+  ],
 }


### PR DESCRIPTION
Now that we have three main branches, I updated the renovate configuration so that once `track/3.5` become the default branch, renovate should act on all `track/X.Y` branches.

I also took this opportunity to address a few pet peeves we had with our previous configuration, namely needlessly bumping the ubuntu runners and the python version.
Therefore, this PR supersedes #155 and should unblock #151 and #153
