### PR TITLE
[PRA-165] Update docs to reflect correct behavior when S3 region is not configured

### DIFF
--- a/docs/how-to/advanced-scheduling.md
+++ b/docs/how-to/advanced-scheduling.md
@@ -322,7 +322,7 @@ juju config -m <charmed_spark_juju_model> namespace-node-affinity settings_yaml=
 This is it! Any new Juju application deployment will now get the desired tolerations and affinities:
 
 ```shell
-juju deploy -m <charmed_spark_juju_model> s3-integrator s3
+juju deploy -m <charmed_spark_juju_model> s3-integrator s3 --channel 2/stable
 ```
 
 You can check that the configuration is properly applied using:

--- a/docs/how-to/apache-kyuubi/back-up-and-restore.md
+++ b/docs/how-to/apache-kyuubi/back-up-and-restore.md
@@ -69,6 +69,7 @@ juju config <metastore-backup> \
   bucket=<S3_BUCKET> \
   endpoint=<S3_ENDPOINT> \
   path=<S3_PATH> \
+  region=<S3_REGION> \
   credentials=<SECRET_URI_FROM_PREVIOUS_STEP>
 ```
 

--- a/docs/how-to/deploy/kyuubi.md
+++ b/docs/how-to/deploy/kyuubi.md
@@ -109,6 +109,9 @@ Once properly configured, the `s3-integrator` app should go to an active and idl
 juju integrate s3-integrator spark-integration-hub-k8s
 ```
 
+> [!NOTE]  
+> If the `region` is not configured in the `s3-integrator` charm before integrating it with `spark-integration-hub-k8s` charm, the `spark-integration-hub-k8s` charm uses `us-east-1` as the region to send requests to S3.
+
 After that, `kyuubi-k8s` app becomes blocked with the `Missing authentication database relation` message.
 
 ### Azure DataLake

--- a/docs/how-to/manage-service-accounts/using-integration-hub.md
+++ b/docs/how-to/manage-service-accounts/using-integration-hub.md
@@ -66,6 +66,7 @@ juju config s3-integrator \
   bucket=<S3_BUCKET> \
   endpoint=<S3_ENDPOINT> \
   path=spark-events \
+  region=<S3_REGION> \
   credentials=<SECRET_URI_FROM_PREVIOUS_STEP>
 ```
 
@@ -81,6 +82,9 @@ the Integration Hub for Apache Spark charm can be integrated with
 ```shell
 juju integrate s3-integrator spark-integration-hub-k8s
 ```
+
+> [!NOTE]  
+> If the `region` is not configured in the `s3-integrator` charm before integrating it with `spark-integration-hub-k8s` charm, the `spark-integration-hub-k8s` charm uses `us-east-1` as the region to send requests to S3.
 
 This will automatically add relevant configuration properties to your Spark jobs,
 depending on the storage backend.

--- a/docs/tutorial/1-environment-setup.md
+++ b/docs/tutorial/1-environment-setup.md
@@ -534,6 +534,9 @@ And finally, integrate `s3-integrator` with `spark-integration-hub-k8s` charm:
 juju integrate s3-integrator spark-integration-hub-k8s
 ```
 
+> [!NOTE]  
+> If the `region` is not configured in the `s3-integrator` charm before integrating it with `spark-integration-hub-k8s` charm, the `spark-integration-hub-k8s` charm uses `us-east-1` as the region to send requests to S3.
+
 <!-- test:await-idle --timeout 600 -->
 
 Wait for both charms to reach `active/idle` status:

--- a/docs/tutorial/4-history-server.md
+++ b/docs/tutorial/4-history-server.md
@@ -111,6 +111,9 @@ Once properly configured, the `s3-integrator` app should go to an active and idl
 juju integrate s3-integrator spark-history-server-k8s
 ```
 
+> [!NOTE]  
+> If the `region` is not configured in the `s3-integrator` charm before integrating it with `spark-history-server-k8s` charm, the `spark-history-server-k8s` charm uses `us-east-1` as the region to send requests to S3.
+
 <!-- test:await-idle --timeout 600 -->
 
 Let's view the status of the Juju model now with the command `watch -c juju status --color --relations`. Once deployment and integration have been completed for the charms, the status should look similar to the following:


### PR DESCRIPTION
## Description

The PR updates the docs, such that we mention the correct behavior when region is not specifed with s3-integrator charm when related to integraiton hub and spark-history-server.

This will solve https://github.com/canonical/spark-history-server-k8s-operator/issues/133

## Checklist

- [x] I have added or updated any relevant documentation.
