### PR TITLE
[BACKPORT] Exclude pandas v3 from renovate updates (3.5)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,11 @@
       "matchManagers": ["github-actions"],
       "matchDepNames": ["python"],
       "enabled": false
+    },
+    {
+      "description": "Block pandas v3 updates due to python3.11 requirement",
+      "matchPackageNames": ["pandas"],
+      "allowedVersions": "<3.0.0"
     }
   ],
 }


### PR DESCRIPTION
Backport #298 