### PR TITLE
[PRA-353] Add dependency minimum release age (3.4)

### DIFF
--- a/python/poetry.toml
+++ b/python/poetry.toml
@@ -1,0 +1,2 @@
+[solver]
+min-release-age = 1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,9 +11,6 @@ license = "Apache-2.0"
 readme = "README.md"
 packages = [{ include = "spark_test" }]
 
-[tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.9"
-
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 spark8t = ">=0.0.12"


### PR DESCRIPTION
Similar to spark8t, we remove the poetry plugin export error-ing with the minimum release age configuration
