### PR TITLE
[PRA-354] Migrate and improve renovate config (3.5)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,30 +1,31 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>canonical/data-platform//renovate_presets/charm.json5",
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "github>canonical/data-platform//renovate_presets/base.json5",
+    "helpers:pinGitHubActionDigests",
   ],
-  "reviewers": [
-    "welpaolo",
-    "theoctober19th",
-    "batalex",
-  ],
-  "baseBranchPatterns": ["/^track\\/[0-9]+\\.[0-9]+$/"],
-  "schedule": ["* 3 * * 5"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 3 * * 5"]
+  // Between 1AM and 6:59AM, first Friday of the month
+  schedule: ["* 1-6 1-7 * 5"],
+  lockFileMaintenance: {
+    enabled: true,
+    // Between 1AM and 6:59AM, Friday mid-month
+    schedule: ["* 1-6 14-21 * 5"],
   },
-  "ignoreDeps": ["ubuntu"],
-  "packageRules": [
+  baseBranchPatterns: ["/^track\\/[0-9]+\\.[0-9]+$/"],
+  useBaseBranchConfig: "merge",
+  commitMessagePrefix: "[RENOVATE] ",
+  ignoreDeps: ["ubuntu"],
+  enabledManagers: ["github-actions", "poetry"],
+  packageRules: [
     {
-      "matchManagers": ["github-actions"],
-      "matchDepNames": ["python"],
-      "enabled": false
+      matchManagers: ["github-actions"],
+      matchDepNames: ["python"],
+      enabled: false,
     },
     {
-      "description": "Block pandas v3 updates due to python3.11 requirement",
-      "matchPackageNames": ["pandas"],
-      "allowedVersions": "<3.0.0"
-    }
+      description: "Block pandas v3 updates due to python3.11 requirement",
+      matchPackageNames: ["pandas"],
+      allowedVersions: "<3.0.0",
+    },
   ],
 }


### PR DESCRIPTION
This PR migrates the renovate config to a prettified format and updates the following bits:
- GH actions to be pinned to their digest
- No more reviewers since we have CODEOWNERS
- Use the base preset, but enable the poetry manager
- Add the `[RENOVATE] ` prefix
- Allow `track/3.4` and `track/4.0` to override the config


On the schedule part, we stay here on the first friday of the month to balance the # of PRs with regards to the charms. The lock file maintenance has a two weeks offset to reduce the conflicts to solve.